### PR TITLE
Backend Executor: wait for condition before returning

### DIFF
--- a/backend/runtimestate/runtimestate.go
+++ b/backend/runtimestate/runtimestate.go
@@ -278,22 +278,22 @@ func Name(s *protos.OrchestrationRuntimeState) (string, error) {
 	return s.StartEvent.Name, nil
 }
 
-func Input(s *protos.OrchestrationRuntimeState) (string, error) {
+func Input(s *protos.OrchestrationRuntimeState) (*wrapperspb.StringValue, error) {
 	if s.StartEvent == nil {
-		return "", api.ErrNotStarted
+		return nil, api.ErrNotStarted
 	}
 
 	// REVIEW: Should we distinguish between no input and the empty string?
-	return s.StartEvent.Input.GetValue(), nil
+	return s.StartEvent.Input, nil
 }
 
-func Output(s *protos.OrchestrationRuntimeState) (string, error) {
+func Output(s *protos.OrchestrationRuntimeState) (*wrapperspb.StringValue, error) {
 	if s.CompletedEvent == nil {
-		return "", api.ErrNotCompleted
+		return nil, api.ErrNotCompleted
 	}
 
 	// REVIEW: Should we distinguish between no output and the empty string?
-	return s.CompletedEvent.Result.GetValue(), nil
+	return s.CompletedEvent.Result, nil
 }
 
 func RuntimeStatus(s *protos.OrchestrationRuntimeState) protos.OrchestrationStatus {

--- a/tests/runtimestate_test.go
+++ b/tests/runtimestate_test.go
@@ -231,7 +231,7 @@ func Test_RuntimeState_ContinueAsNew(t *testing.T) {
 					assert.Equal(t, expectedName, ec.Name)
 				}
 				if input, err := runtimestate.Input(state); assert.NoError(t, err) {
-					assert.Equal(t, continueAsNewInput, input)
+					assert.Equal(t, continueAsNewInput, input.GetValue())
 				}
 			}
 			assert.NotNil(t, state.NewEvents[2].Timestamp)


### PR DESCRIPTION
Fixes race conditions by forcing client executor calls to be synchronous when backend calls are not.