### PR TITLE
Task: Remove panic from processing event

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -63,8 +63,7 @@ func (t *completableTask) Await(v any) error {
 
 		ok, err := t.orchestrationCtx.processNextEvent()
 		if err != nil {
-			// TODO: If there is an error here, we need some kind of well-known panic to kill the orchestration
-			panic(err)
+			return err
 		}
 		if !ok {
 			break


### PR DESCRIPTION
Remove panic when processing an event occurs. Programs should never panic. We should instead return the error gracefully.

There are still other panics being used to send signals which should be removed in a future change.