### PR TITLE
chore: Upgrade golang version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21 as build
+FROM golang:1.24 AS build
 
 COPY . /root
 WORKDIR /root


### PR DESCRIPTION
In the durabletask-java library there are integration test that initializes durable task as a sidecar 
- https://github.com/dapr/durabletask-java/blob/5094800647f2e9c59f23d8e2a57cdda571abb241/.github/workflows/build-validation.yml#L77

Current implementation is using a custom image that we do not support. There is a [PR](https://github.com/dapr/durabletask-java/pull/33) ready to move this to use our repo but to be able to build the image we need to upgrade golang version on the dockerfile.


