### PR TITLE
Parallel lock nil if not set

### DIFF
--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -173,7 +173,7 @@ func Test_TaskWorker(t *testing.T) {
 	}
 	tp.AddWorkItems(first, second)
 
-	worker := backend.NewTaskWorker[*backend.ActivityWorkItem](tp, logger)
+	worker := backend.NewTaskWorker[*backend.ActivityWorkItem](tp, logger, backend.WithMaxParallelism(1))
 
 	worker.Start(ctx)
 
@@ -220,7 +220,7 @@ func Test_StartAndStop(t *testing.T) {
 	}
 	tp.AddWorkItems(&first, &second)
 
-	worker := backend.NewTaskWorker[*backend.ActivityWorkItem](tp, logger)
+	worker := backend.NewTaskWorker[*backend.ActivityWorkItem](tp, logger, backend.WithMaxParallelism(1))
 
 	worker.Start(ctx)
 


### PR DESCRIPTION
Update the worker parallel lock to be nil if not set. This saves memory when no concurrency limit is set.