### PR TITLE
add orchestration processor idempotency test

### DIFF
--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -74,6 +74,11 @@ func Test_TryProcessSingleOrchestrationWorkItem_BasicFlow(t *testing.T) {
 	}, 1*time.Second, 100*time.Millisecond)
 
 	worker.StopAndDrain()
+
+	t.Logf("state.NewEvents: %v", state.NewEvents)
+	require.Len(t, state.NewEvents, 2)
+	require.True(t, state.NewEvents[0].GetOrchestratorStarted() != nil)
+	require.True(t, state.NewEvents[1].GetExecutionStarted() != nil)
 }
 
 func Test_TryProcessSingleOrchestrationWorkItem_Idempotency(t *testing.T) {
@@ -106,12 +111,20 @@ func Test_TryProcessSingleOrchestrationWorkItem_Idempotency(t *testing.T) {
 	be := mocks.NewBackend(t)
 	ex := mocks.NewExecutor(t)
 
+	callNumber := 0
+	ex.EXPECT().ExecuteOrchestrator(anyContext, wi.InstanceID, wi.State.OldEvents, mock.Anything).RunAndReturn(func(ctx context.Context, iid api.InstanceID, oldEvents []*protos.HistoryEvent, newEvents []*protos.HistoryEvent) (*protos.OrchestratorResponse, error) {
+		callNumber++
+		logger.Debugf("execute orchestrator called %d times", callNumber)
+		if callNumber == 1 {
+			return nil, errors.New("dummy error")
+		}
+		return &protos.OrchestratorResponse{}, nil
+	}).Times(2)
+
 	be.EXPECT().NextOrchestrationWorkItem(anyContext).Return(wi, nil).Once()
-	ex.EXPECT().ExecuteOrchestrator(anyContext, wi.InstanceID, wi.State.OldEvents, mock.Anything).Return(nil, errors.New("dummy error")).Once()
 	be.EXPECT().AbandonOrchestrationWorkItem(anyContext, wi).Return(nil).Once()
 
 	be.EXPECT().NextOrchestrationWorkItem(anyContext).Return(wi, nil).Once()
-	ex.EXPECT().ExecuteOrchestrator(anyContext, wi.InstanceID, wi.State.OldEvents, mock.Anything).Return(&protos.OrchestratorResponse{}, nil).Once()
 	be.EXPECT().CompleteOrchestrationWorkItem(anyContext, wi).RunAndReturn(func(ctx context.Context, owi *backend.OrchestrationWorkItem) error {
 		completed.Store(true)
 		return nil
@@ -131,6 +144,12 @@ func Test_TryProcessSingleOrchestrationWorkItem_Idempotency(t *testing.T) {
 	}, 2*time.Second, 100*time.Millisecond)
 
 	worker.StopAndDrain()
+
+	t.Logf("state.NewEvents: %v", wi.State.NewEvents)
+	require.Len(t, wi.State.NewEvents, 3)
+	require.True(t, wi.State.NewEvents[0].GetOrchestratorStarted() != nil)
+	require.True(t, wi.State.NewEvents[1].GetExecutionStarted() != nil)
+	require.True(t, wi.State.NewEvents[2].GetOrchestratorStarted() != nil)
 }
 
 func Test_TryProcessSingleOrchestrationWorkItem_ExecutionStartedAndCompleted(t *testing.T) {
@@ -213,6 +232,12 @@ func Test_TryProcessSingleOrchestrationWorkItem_ExecutionStartedAndCompleted(t *
 	}, 1*time.Second, 100*time.Millisecond)
 
 	worker.StopAndDrain()
+
+	t.Logf("state.NewEvents: %v", state.NewEvents)
+	require.Len(t, state.NewEvents, 3)
+	require.True(t, state.NewEvents[0].GetOrchestratorStarted() != nil)
+	require.True(t, state.NewEvents[1].GetExecutionStarted() != nil)
+	require.True(t, state.NewEvents[2].GetExecutionCompleted() != nil)
 }
 
 func Test_TaskWorker(t *testing.T) {


### PR DESCRIPTION
adds a new unit test that reproduces a bug I'm troubleshooting

the handling of execution started event is not idempotent and it doesn't guarantee that the orchestrator is actually executed when retried

my expectation is that when `ProcessWorkItem` returns an error, it is expected that `ProcessWorkItem` can be retried in the future with the same WorkItem, then the source of problems is when the state passed inside of the WorkItem is the same as the state used for the first `ProcessWorkItem` invocation. In that case `ProcessWorkItem` doesn't have an idempotent behavior and in the second invocation doesn't call `w.executor.ExecuteOrchestrator`

So the sequence of events I would expect are:
- WorkItem is provided in `NextWorkItem`
- WorkItem is processed in `ProcessWorkItem`, it invokes `executor.ExecuteOrchestrator` but it fails and `ProcessWorkItem` returns an error
- Same WorkItem (with same state) is provided again in `NextWorkItem`
- WorkItem is processed in `ProcessWorkItem` , it SHOULD invoke `executor.ExecuteOrchestrator` 