### PR TITLE
Significantly reduce number of go routines in executor

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -322,7 +322,7 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 	}()
 
 	ch := make(chan *protos.WorkItem)
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		for {
 			select {

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -378,8 +378,7 @@ func (g *grpcExecutor) sendWorkItem(stream protos.TaskHubSidecarService_GetWorkI
 ) error {
 	select {
 	case <-stream.Context().Done():
-		g.logger.Errorf("timed out while sending work item")
-		return fmt.Errorf("timed out while sending work item: %w", stream.Context().Err())
+		return stream.Context().Err()
 	case ch <- wi:
 	}
 

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -369,14 +369,12 @@ func (g *grpcExecutor) sendWorkItem(stream protos.TaskHubSidecarService_GetWorkI
 	}
 
 	errCh := make(chan error, 2)
-	go func() {
-		select {
-		case errCh <- stream.Send(wi):
-		case <-ctx.Done():
-			g.logger.Errorf("timed out while sending work item")
-			errCh <- fmt.Errorf("timed out while sending work item: %w", ctx.Err())
-		}
-	}()
+	select {
+	case errCh <- stream.Send(wi):
+	case <-ctx.Done():
+		g.logger.Errorf("timed out while sending work item")
+		errCh <- fmt.Errorf("timed out while sending work item: %w", ctx.Err())
+	}
 
 	return <-errCh
 }


### PR DESCRIPTION
Significantly reduce number of go routines generated by sending work to the client.