### PR TITLE
Create vanity `workflow` client

### DIFF
--- a/api/orchestration.go
+++ b/api/orchestration.go
@@ -80,6 +80,7 @@ func WithInstanceID(id InstanceID) NewOrchestrationOptions {
 }
 
 // WithOrchestrationIdReusePolicy configures Orchestration ID reuse policy.
+// Deprecated.
 func WithOrchestrationIdReusePolicy(policy *protos.OrchestrationIdReusePolicy) NewOrchestrationOptions {
 	return func(req *protos.CreateInstanceRequest) error {
 		// initialize CreateInstanceOption

--- a/task/activity.go
+++ b/task/activity.go
@@ -11,7 +11,7 @@ import (
 	"github.com/dapr/durabletask-go/api/protos"
 )
 
-type callActivityOption func(*callActivityOptions) error
+type CallActivityOption func(*callActivityOptions) error
 
 type callActivityOptions struct {
 	rawInput    *wrapperspb.StringValue
@@ -59,7 +59,7 @@ func (policy *RetryPolicy) Validate() error {
 	return nil
 }
 
-func WithActivityAppID(targetAppID string) callActivityOption {
+func WithActivityAppID(targetAppID string) CallActivityOption {
 	return func(opt *callActivityOptions) error {
 		opt.targetAppID = &targetAppID
 		return nil
@@ -68,7 +68,7 @@ func WithActivityAppID(targetAppID string) callActivityOption {
 
 // WithActivityInput configures an input for an activity invocation.
 // The specified input must be JSON serializable.
-func WithActivityInput(input any) callActivityOption {
+func WithActivityInput(input any) CallActivityOption {
 	return func(opt *callActivityOptions) error {
 		data, err := marshalData(input)
 		if err != nil {
@@ -80,14 +80,14 @@ func WithActivityInput(input any) callActivityOption {
 }
 
 // WithRawActivityInput configures a raw input for an activity invocation.
-func WithRawActivityInput(input *wrapperspb.StringValue) callActivityOption {
+func WithRawActivityInput(input *wrapperspb.StringValue) CallActivityOption {
 	return func(opt *callActivityOptions) error {
 		opt.rawInput = input
 		return nil
 	}
 }
 
-func WithActivityRetryPolicy(policy *RetryPolicy) callActivityOption {
+func WithActivityRetryPolicy(policy *RetryPolicy) CallActivityOption {
 	return func(opt *callActivityOptions) error {
 		if policy == nil {
 			return nil

--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -58,14 +58,14 @@ type callSubOrchestratorOptions struct {
 	retryPolicy *RetryPolicy
 }
 
-// subOrchestratorOption is a functional option type for the CallSubOrchestrator orchestrator method.
-type subOrchestratorOption func(*callSubOrchestratorOptions) error
+// SubOrchestratorOption is a functional option type for the CallSubOrchestrator orchestrator method.
+type SubOrchestratorOption func(*callSubOrchestratorOptions) error
 
 // ContinueAsNewOption is a functional option type for the ContinueAsNew orchestrator method.
 type ContinueAsNewOption func(*OrchestrationContext)
 
 // WithSubOrchestratorAppID is a functional option type for the CallSubOrchestrator orchestrator method that specifies the app ID of the target activity.
-func WithSubOrchestratorAppID(appID string) subOrchestratorOption {
+func WithSubOrchestratorAppID(appID string) SubOrchestratorOption {
 	return func(opts *callSubOrchestratorOptions) error {
 		opts.targetAppID = &appID
 		return nil
@@ -82,7 +82,7 @@ func WithKeepUnprocessedEvents() ContinueAsNewOption {
 
 // WithSubOrchestratorInput is a functional option type for the CallSubOrchestrator
 // orchestrator method that takes an input value and marshals it to JSON.
-func WithSubOrchestratorInput(input any) subOrchestratorOption {
+func WithSubOrchestratorInput(input any) SubOrchestratorOption {
 	return func(opts *callSubOrchestratorOptions) error {
 		bytes, err := marshalData(input)
 		if err != nil {
@@ -95,7 +95,7 @@ func WithSubOrchestratorInput(input any) subOrchestratorOption {
 
 // WithRawSubOrchestratorInput is a functional option type for the CallSubOrchestrator
 // orchestrator method that takes a raw input value.
-func WithRawSubOrchestratorInput(input *wrapperspb.StringValue) subOrchestratorOption {
+func WithRawSubOrchestratorInput(input *wrapperspb.StringValue) SubOrchestratorOption {
 	return func(opts *callSubOrchestratorOptions) error {
 		opts.rawInput = input
 		return nil
@@ -104,14 +104,14 @@ func WithRawSubOrchestratorInput(input *wrapperspb.StringValue) subOrchestratorO
 
 // WithSubOrchestrationInstanceID is a functional option type for the CallSubOrchestrator
 // orchestrator method that specifies the instance ID of the sub-orchestration.
-func WithSubOrchestrationInstanceID(instanceID string) subOrchestratorOption {
+func WithSubOrchestrationInstanceID(instanceID string) SubOrchestratorOption {
 	return func(opts *callSubOrchestratorOptions) error {
 		opts.instanceID = instanceID
 		return nil
 	}
 }
 
-func WithSubOrchestrationRetryPolicy(policy *RetryPolicy) subOrchestratorOption {
+func WithSubOrchestrationRetryPolicy(policy *RetryPolicy) SubOrchestratorOption {
 	return func(opt *callSubOrchestratorOptions) error {
 		if policy == nil {
 			return nil
@@ -267,7 +267,7 @@ func (octx *OrchestrationContext) GetInput(v any) error {
 // CallActivity schedules an asynchronous invocation of an activity function. The [activity]
 // parameter can be either the name of an activity as a string or can be a pointer to the function
 // that implements the activity, in which case the name is obtained via reflection.
-func (ctx *OrchestrationContext) CallActivity(activity interface{}, opts ...callActivityOption) Task {
+func (ctx *OrchestrationContext) CallActivity(activity interface{}, opts ...CallActivityOption) Task {
 	options := new(callActivityOptions)
 	for _, configure := range opts {
 		if err := configure(options); err != nil {
@@ -317,8 +317,7 @@ func (ctx *OrchestrationContext) internalScheduleActivity(activityName, taskExec
 	return task
 }
 
-// TODO: cassie wire appID into suborchestration options too for cross app wf
-func (ctx *OrchestrationContext) CallSubOrchestrator(orchestrator interface{}, opts ...subOrchestratorOption) Task {
+func (ctx *OrchestrationContext) CallSubOrchestrator(orchestrator interface{}, opts ...SubOrchestratorOption) Task {
 	options := new(callSubOrchestratorOptions)
 	for _, configure := range opts {
 		if err := configure(options); err != nil {
@@ -421,7 +420,7 @@ func computeNextDelay(currentTimeUtc time.Time, policy RetryPolicy, attempt int,
 }
 
 // CreateTimer schedules a durable timer that expires after the specified delay.
-func (ctx *OrchestrationContext) CreateTimer(delay time.Duration, opts ...createTimerOption) Task {
+func (ctx *OrchestrationContext) CreateTimer(delay time.Duration, opts ...CreateTimerOption) Task {
 	options := new(createTimerOptions)
 	for _, configure := range opts {
 		if err := configure(options); err != nil {

--- a/task/timer.go
+++ b/task/timer.go
@@ -1,12 +1,12 @@
 package task
 
-type createTimerOption func(*createTimerOptions) error
+type CreateTimerOption func(*createTimerOptions) error
 
 type createTimerOptions struct {
 	name *string
 }
 
-func WithTimerName(name string) createTimerOption {
+func WithTimerName(name string) CreateTimerOption {
 	return func(opt *createTimerOptions) error {
 		opt.name = &name
 		return nil

--- a/workflow/activity.go
+++ b/workflow/activity.go
@@ -1,0 +1,50 @@
+package workflow
+
+import (
+	"time"
+
+	"github.com/dapr/durabletask-go/task"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+type CallActivityOption task.CallActivityOption
+
+type RetryPolicy struct {
+	// Max number of attempts to try the activity call, first execution inclusive
+	MaxAttempts int
+	// Timespan to wait for the first retry
+	InitialRetryInterval time.Duration
+	// Used to determine rate of increase of back-off
+	BackoffCoefficient float64
+	// Max timespan to wait for a retry
+	MaxRetryInterval time.Duration
+	// Total timeout across all the retries performed
+	RetryTimeout time.Duration
+	// Optional function to control if retries should proceed
+	Handle func(error) bool
+}
+
+func WithActivityAppID(targetAppID string) CallActivityOption {
+	return CallActivityOption(task.WithActivityAppID(targetAppID))
+}
+
+// WithActivityInput configures an input for an activity invocation. The
+// specified input must be JSON serializable.
+func WithActivityInput(input any) CallActivityOption {
+	return CallActivityOption(task.WithActivityInput(input))
+}
+
+// WithRawActivityInput configures a raw input for an activity invocation.
+func WithRawActivityInput(input *wrapperspb.StringValue) CallActivityOption {
+	return CallActivityOption(task.WithRawActivityInput(input))
+}
+
+func WithActivityRetryPolicy(policy *RetryPolicy) CallActivityOption {
+	return CallActivityOption(task.WithActivityRetryPolicy((*task.RetryPolicy)(policy)))
+}
+
+// ActivityContext is the context parameter type for activity implementations.
+type ActivityContext task.ActivityContext
+
+// Activity is the functional interface for activity implementations.
+type Activity func(ActivityContext) (any, error)

--- a/workflow/api.go
+++ b/workflow/api.go
@@ -1,0 +1,103 @@
+package workflow
+
+import (
+	"time"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/kit/ptr"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+type NewWorkflowOptions api.NewOrchestrationOptions
+type FetchWorkflowMetadataOptions api.FetchOrchestrationMetadataOptions
+type RaiseEventOptions api.RaiseEventOptions
+type TerminateOptions api.TerminateOptions
+type PurgeOptions api.PurgeOptions
+type RerunOptions api.RerunOptions
+
+type WorkflowMetadata protos.OrchestrationMetadata
+
+// WithInstanceID configures an explicit workflow instance ID. If not
+// specified, a random UUID value will be used for the workflow instance ID.
+func WithInstanceID(id string) NewWorkflowOptions {
+	return NewWorkflowOptions(api.WithInstanceID(api.InstanceID(id)))
+}
+
+// WithInput configures an input for the workflow. The specified input must be
+// serializable.
+func WithInput(input any) NewWorkflowOptions {
+	return NewWorkflowOptions(api.WithInput(input))
+}
+
+// WithRawInput configures an input for the workflow. The specified input must
+// be a string.
+func WithRawInput(rawInput *wrapperspb.StringValue) NewWorkflowOptions {
+	return NewWorkflowOptions(api.WithRawInput(rawInput))
+}
+
+// WithStartTime configures a start time at which the workflow should start
+// running. Note that the actual start time could be later than the specified
+// start time if the task hub is under load or if the app is not running at the
+// specified start time.
+func WithStartTime(startTime time.Time) NewWorkflowOptions {
+	return NewWorkflowOptions(api.WithStartTime(startTime))
+}
+
+// WithFetchPayloads configures whether to load workflow inputs, outputs, and
+// custom status values, which could be large.
+func WithFetchPayloads(fetchPayloads bool) FetchWorkflowMetadataOptions {
+	return FetchWorkflowMetadataOptions(api.WithFetchPayloads(fetchPayloads))
+}
+
+// WithEventPayload configures an event payload. The specified payload must be
+// serializable.
+func WithEventPayload(data any) RaiseEventOptions {
+	return RaiseEventOptions(api.WithEventPayload(data))
+}
+
+// WithRawEventData configures an event payload that is a raw, unprocessed
+// string (e.g. JSON data).
+func WithRawEventData(data *wrapperspb.StringValue) RaiseEventOptions {
+	return RaiseEventOptions(api.WithRawEventData(data))
+}
+
+// WithOutput configures an output for the terminated workflow. The specified
+// output must be serializable.
+func WithOutput(data any) TerminateOptions {
+	return TerminateOptions(api.WithOutput(data))
+}
+
+// WithRawOutput configures a raw, unprocessed output (i.e. pre-serialized) for
+// the terminated workflow.
+func WithRawOutput(data *wrapperspb.StringValue) TerminateOptions {
+	return TerminateOptions(api.WithRawOutput(data))
+}
+
+// WithRecursiveTerminate configures whether to terminate all child-workflows
+// created by the target workflow.
+func WithRecursiveTerminate(recursive bool) TerminateOptions {
+	return TerminateOptions(api.WithRecursiveTerminate(recursive))
+}
+
+// WithRecursivePurge configures whether to purge all child-workflows created
+// by the target workflow.
+func WithRecursivePurge(recursive bool) PurgeOptions {
+	return PurgeOptions(api.WithRecursivePurge(recursive))
+}
+
+func WorkflowMetadataIsRunning(o *WorkflowMetadata) bool {
+	return api.OrchestrationMetadataIsComplete(ptr.Of(protos.OrchestrationMetadata(*o)))
+}
+
+func WorkflowMetadataIsComplete(o *WorkflowMetadata) bool {
+	return api.OrchestrationMetadataIsComplete(ptr.Of(protos.OrchestrationMetadata(*o)))
+}
+
+func WithRerunInput(input any) RerunOptions {
+	return RerunOptions(api.WithRerunInput(input))
+}
+
+func WithRerunNewInstanceID(id string) RerunOptions {
+	return RerunOptions(api.WithRerunNewInstanceID(api.InstanceID(id)))
+}

--- a/workflow/client.go
+++ b/workflow/client.go
@@ -1,0 +1,146 @@
+package workflow
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+)
+
+type Client struct {
+	thgc *client.TaskHubGrpcClient
+}
+
+// NewClient creates a client that can be used to manage worfklows.
+func NewClient(cc grpc.ClientConnInterface) *Client {
+	return NewClientWithLogger(cc, backend.DefaultLogger())
+}
+
+func NewClientWithLogger(cc grpc.ClientConnInterface, logger backend.Logger) *Client {
+	return &Client{
+		thgc: client.NewTaskHubGrpcClient(cc, logger),
+	}
+}
+
+// StartWorker starts the workflow runtime to process workflows.
+func (c *Client) StartWorker(ctx context.Context, r *TaskRegistry) error {
+	return c.thgc.StartWorkItemListener(ctx, r.registry)
+}
+
+// ScheduleNewWorkflow schedules a new workflow instance with a specified set
+// of options for execution.
+func (c *Client) ScheduleNewWorkflow(ctx context.Context, orchestrator string, opts ...NewWorkflowOptions) (string, error) {
+	oopts := make([]api.NewOrchestrationOptions, len(opts))
+	for i, o := range opts {
+		oopts[i] = api.NewOrchestrationOptions(o)
+	}
+
+	id, err := c.thgc.ScheduleNewOrchestration(ctx, orchestrator, oopts...)
+	return string(id), err
+}
+
+// FetchWorkflowMetadata fetches metadata for the specified workflow from the
+// configured task hub.
+//
+// api.ErrInstanceNotFound is returned when the specified workflow doesn't
+// exist.
+func (c *Client) FetchWorkflowMetadata(ctx context.Context, id string, opts ...FetchWorkflowMetadataOptions) (*WorkflowMetadata, error) {
+	oops := make([]api.FetchOrchestrationMetadataOptions, len(opts))
+	for i, o := range opts {
+		oops[i] = api.FetchOrchestrationMetadataOptions(o)
+	}
+	meta, err := c.thgc.FetchOrchestrationMetadata(ctx, api.InstanceID(id), oops...)
+	return (*WorkflowMetadata)(meta), err
+}
+
+// WaitForWorkflowStart waits for an workflow to start running and returns an
+// [backend.WorkflowMetadata] object that contains metadata about the started
+// instance.
+//
+// api.ErrInstanceNotFound is returned when the specified workflow doesn't
+// exist.
+func (c *Client) WaitForWorkfowStart(ctx context.Context, id string, opts ...FetchWorkflowMetadataOptions) (*WorkflowMetadata, error) {
+	oops := make([]api.FetchOrchestrationMetadataOptions, len(opts))
+	for i, o := range opts {
+		oops[i] = api.FetchOrchestrationMetadataOptions(o)
+	}
+	meta, err := c.thgc.WaitForOrchestrationStart(ctx, api.InstanceID(id), oops...)
+	return (*WorkflowMetadata)(meta), err
+}
+
+// WaitForWorkflowCompletion waits for an workflow to complete and returns an
+// [backend.WorkflowMetadata] object that contains metadata about the completed
+// instance.
+//
+// api.ErrInstanceNotFound is returned when the specified workflow doesn't
+// exist.
+func (c *Client) WaitForWorkflowCompletion(ctx context.Context, id string, opts ...FetchWorkflowMetadataOptions) (*WorkflowMetadata, error) {
+	oops := make([]api.FetchOrchestrationMetadataOptions, len(opts))
+	for i, o := range opts {
+		oops[i] = api.FetchOrchestrationMetadataOptions(o)
+	}
+	meta, err := c.thgc.WaitForOrchestrationCompletion(ctx, api.InstanceID(id), oops...)
+	return (*WorkflowMetadata)(meta), err
+}
+
+// TerminateWorkflow terminates a running workflow by causing it to stop
+// receiving new events and putting it directly into the TERMINATED state.
+func (c *Client) TerminateWorkflow(ctx context.Context, id string, opts ...TerminateOptions) error {
+	toops := make([]api.TerminateOptions, len(opts))
+	for i, o := range opts {
+		toops[i] = api.TerminateOptions(o)
+	}
+	return c.thgc.TerminateOrchestration(ctx, api.InstanceID(id), toops...)
+}
+
+// RaiseEvent sends an asynchronous event notification to a waiting workflow.
+func (c *Client) RaiseEvent(ctx context.Context, id, eventName string, opts ...RaiseEventOptions) error {
+	oops := make([]api.RaiseEventOptions, len(opts))
+	for i, o := range opts {
+		oops[i] = api.RaiseEventOptions(o)
+	}
+	return c.thgc.RaiseEvent(ctx, api.InstanceID(id), eventName, oops...)
+}
+
+// SuspendWorkflow suspends an workflow instance, halting processing of its
+// events until a "resume" operation resumes it.
+//
+// Note that suspended workflows are still considered to be "running" even
+// though they will not process events.
+func (c *Client) SuspendWorkflow(ctx context.Context, id, reason string) error {
+	return c.thgc.SuspendOrchestration(ctx, api.InstanceID(id), reason)
+}
+
+// ResumeWorkflow resumes an orchestration instance that was previously
+// suspended.
+func (c *Client) ResumeWorkflow(ctx context.Context, id, reason string) error {
+	return c.thgc.ResumeOrchestration(ctx, api.InstanceID(id), reason)
+}
+
+// PurgeWorkflowState deletes the state of the specified workflow instance.
+//
+// [api.api.ErrInstanceNotFound] is returned if the specified workflow instance
+// doesn't exist.
+func (c *Client) PurgeWorkflowState(ctx context.Context, id string, opts ...PurgeOptions) error {
+	oops := make([]api.PurgeOptions, len(opts))
+	for i, o := range opts {
+		oops[i] = api.PurgeOptions(o)
+	}
+	return c.thgc.PurgeOrchestrationState(ctx, api.InstanceID(id), oops...)
+}
+
+// RerunWorkflowFromEvent reruns a workflow from a specific event ID of some
+// source instance ID. If not given, a random new instance ID will be generated
+// and returned. Can optionally give a new input to the target event ID to
+// rerun from.
+func (c *Client) RerunWorkflowFromEvent(ctx context.Context, id string, eventID uint32, opts ...RerunOptions) (string, error) {
+	oops := make([]api.RerunOptions, len(opts))
+	for i, o := range opts {
+		oops[i] = api.RerunOptions(o)
+	}
+	newID, err := c.thgc.RerunWorkflowFromEvent(ctx, api.InstanceID(id), eventID, oops...)
+	return string(newID), err
+}

--- a/workflow/registry.go
+++ b/workflow/registry.go
@@ -1,0 +1,50 @@
+package workflow
+
+import (
+	"github.com/dapr/durabletask-go/task"
+)
+
+// TaskRegistry contains maps of names to corresponding orchestrator and
+// activity functions.
+type TaskRegistry struct {
+	registry *task.TaskRegistry
+}
+
+// NewTaskRegistry returns a new [TaskRegistry] struct.
+func NewTaskRegistry() *TaskRegistry {
+	return &TaskRegistry{
+		registry: task.NewTaskRegistry(),
+	}
+}
+
+// AddWorkflow adds an orchestrator function to the registry. The name of the orchestrator
+// function is determined using reflection.
+func (r *TaskRegistry) AddWorkflow(w Workflow) error {
+	return r.registry.AddOrchestrator(func(ctx *task.OrchestrationContext) (any, error) {
+		return w(&WorkflowContext{ctx})
+	})
+}
+
+// AddWorkflowN adds an orchestrator function to the registry with a
+// specified name.
+func (r *TaskRegistry) AddWorkflowN(name string, w Workflow) error {
+	return r.registry.AddOrchestratorN(name, func(ctx *task.OrchestrationContext) (any, error) {
+		return w(&WorkflowContext{ctx})
+	})
+}
+
+// AddActivity adds an activity function to the registry. The name of the
+// activity function is determined using reflection.
+func (r *TaskRegistry) AddActivity(a Activity) error {
+	return r.registry.AddActivity(func(ctx task.ActivityContext) (any, error) {
+		return a(ctx.(ActivityContext))
+	})
+}
+
+// AddActivityN adds an activity function to the registry with a specified
+// name.
+func (r *TaskRegistry) AddActivityN(name string, a Activity) error {
+	return r.registry.AddActivityN(name, func(ctx task.ActivityContext) (any, error) {
+		return a(ctx.(ActivityContext))
+	})
+}

--- a/workflow/task.go
+++ b/workflow/task.go
@@ -1,0 +1,7 @@
+package workflow
+
+import "github.com/dapr/durabletask-go/task"
+
+// Task is an interface for asynchronous durable tasks. A task is conceptually
+// similar to a future.
+type Task task.Task

--- a/workflow/timer.go
+++ b/workflow/timer.go
@@ -1,0 +1,9 @@
+package workflow
+
+import "github.com/dapr/durabletask-go/task"
+
+type CreateTimerOption task.CreateTimerOption
+
+func WithTimerName(name string) CreateTimerOption {
+	return CreateTimerOption(task.WithTimerName(name))
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -1,0 +1,135 @@
+package workflow
+
+import (
+	"time"
+
+	"github.com/dapr/durabletask-go/task"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// Workflow is the functional interface for workflow functions.
+type Workflow func(ctx *WorkflowContext) (any, error)
+
+// ChildWorkflowOption is a functional option type for the CallChildWorkflow
+// workflow method.
+type ChildWorkflowOption task.SubOrchestratorOption
+
+// WorkflowContext is the parameter type for workflow functions.
+type WorkflowContext struct {
+	oc *task.OrchestrationContext
+}
+
+func (w *WorkflowContext) SetCustomStatus(cs string) {
+	w.oc.SetCustomStatus(cs)
+}
+
+// GetInput unmarshals the serialized workflow input and stores it in [v].
+func (w *WorkflowContext) GetInput(v any) error {
+	return w.oc.GetInput(v)
+}
+
+// CallActivity schedules an asynchronous invocation of an activity function.
+// The [activity] parameter can be either the name of an activity as a string
+// or can be a pointer to the function that implements the activity, in which
+// case the name is obtained via reflection.
+func (w *WorkflowContext) CallActivity(activity any, opts ...CallActivityOption) Task {
+	oopts := make([]task.CallActivityOption, len(opts))
+	for i, o := range opts {
+		oopts[i] = task.CallActivityOption(o)
+	}
+	return w.oc.CallActivity(activity, oopts...)
+}
+
+func (w *WorkflowContext) CallChildWorkflow(workflow any, opts ...ChildWorkflowOption) Task {
+	oopts := make([]task.SubOrchestratorOption, len(opts))
+	for i, o := range opts {
+		oopts[i] = task.SubOrchestratorOption(o)
+	}
+	return w.oc.CallSubOrchestrator(workflow, oopts...)
+}
+
+// CreateTimer schedules a durable timer that expires after the specified
+// delay.
+func (w *WorkflowContext) CreateTimer(delay time.Duration, opts ...CreateTimerOption) Task {
+	oopts := make([]task.CreateTimerOption, len(opts))
+	for i, o := range opts {
+		oopts[i] = task.CreateTimerOption(o)
+	}
+	return w.oc.CreateTimer(delay, oopts...)
+}
+
+// WaitForSingleEvent creates a task that is completed only after an event
+// named [eventName] is received by this workflow or when the specified
+// timeout expires.
+//
+// The [timeout] parameter can be used to define a timeout for receiving the
+// event. If the timeout expires before the named event is received, the task
+// will be completed and will return a timeout error value [ErrTaskCanceled]
+// when awaited. Otherwise, the awaited task will return the deserialized
+// payload of the received event. A Duration value of zero returns a canceled
+// task if the event isn't already available in the history. Use a negative
+// Duration to wait indefinitely for the event to be received.
+//
+// Workflows can wait for the same event name multiple times, so waiting for
+// multiple events with the same name is allowed. Each event received by an
+// workflow will complete just one task returned by this method.
+//
+// Note that event names are case-insensitive.
+func (w *WorkflowContext) WaitForSingleEvent(eventName string, timeout time.Duration) Task {
+	return w.oc.WaitForSingleEvent(eventName, timeout)
+}
+
+func (w *WorkflowContext) ContinueAsNew(newInput any, options ...ContinueAsNewOption) {
+	oopts := make([]task.ContinueAsNewOption, len(options))
+	for i, o := range options {
+		oopts[i] = task.ContinueAsNewOption(o)
+	}
+	w.oc.ContinueAsNew(newInput, oopts...)
+}
+
+// WithChildWorkflowAppID is a functional option type for the CallChildWorkflow
+// workflow method that specifies the app ID of the target activity.
+func WithChildWorkflowAppID(appID string) ChildWorkflowOption {
+	return ChildWorkflowOption(task.WithSubOrchestratorAppID(appID))
+}
+
+// ContinueAsNewOption is a functional option type for the ContinueAsNew
+// workflow method.
+type ContinueAsNewOption task.ContinueAsNewOption
+
+// WithKeepUnprocessedEvents returns a ContinueAsNewOptions struct that
+// instructs the runtime to carry forward any unprocessed external events to
+// the new instance.
+func WithKeepUnprocessedEvents() ContinueAsNewOption {
+	return ContinueAsNewOption(task.WithKeepUnprocessedEvents())
+}
+
+// WithChildWorkflowInput is a functional option type for the CallChildWorkflow
+// workflow method that takes an input value and marshals it to JSON.
+func WithChildWorkflowInput(input any) ChildWorkflowOption {
+	return ChildWorkflowOption(task.WithSubOrchestratorInput(input))
+}
+
+// WithRawChildWorkflowInput is a functional option type for the
+// CallChildWorkflow workflow method that takes a raw input value.
+func WithRawChildWorkflowInput(input *wrapperspb.StringValue) ChildWorkflowOption {
+	return ChildWorkflowOption(task.WithRawSubOrchestratorInput(input))
+}
+
+// WithChildWorkflowInstanceID is a functional option type for the
+// CallChildWorkflow workflow method that specifies the instance ID of the
+// child-workflow.
+func WithChildWorkflowInstanceID(instanceID string) ChildWorkflowOption {
+	return ChildWorkflowOption(task.WithSubOrchestrationInstanceID(instanceID))
+}
+
+func WithChildWorkflowRetryPolicy(policy *RetryPolicy) ChildWorkflowOption {
+	return ChildWorkflowOption(task.WithSubOrchestrationRetryPolicy(&task.RetryPolicy{
+		MaxAttempts:          policy.MaxAttempts,
+		InitialRetryInterval: policy.InitialRetryInterval,
+		BackoffCoefficient:   policy.BackoffCoefficient,
+		MaxRetryInterval:     policy.MaxRetryInterval,
+		RetryTimeout:         policy.RetryTimeout,
+		Handle:               policy.Handle,
+	}))
+}


### PR DESCRIPTION
Create a `workflow` vanity package to rename to more idiomatic naming.

Deprecates ID ReusePolicy.