### PR TITLE
chore: add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners are the maintainers and approvers of this repo
+*       @dapr/maintainers-go-sdk @dapr/approvers-go-sdk @dapr/maintainers-dapr @dapr/approvers-dapr

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners are the maintainers and approvers of this repo
-*       @dapr/maintainers-go-sdk @dapr/approvers-go-sdk @dapr/maintainers-dapr @dapr/approvers-dapr
+*       @dapr/maintainers-dapr @dapr/approvers-dapr


### PR DESCRIPTION
This PR adds CODEOWNERS file since these durabletask is a natural extension of the SDK and should follow the same ownership.