### PR TITLE
Fix: Make external event timer backwards compatible

### DIFF
--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -19,6 +20,14 @@ import (
 	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/kit/ptr"
 )
+
+// externalEventIndefiniteFireAt is the sentinel fire-at value used for the
+// synthetic timer backing WaitForExternalEvent calls with a non-positive
+// timeout. It is chosen far enough in the future that it effectively never
+// fires, and is used on replay to recognize optional pending timers that
+// may be absent from histories produced by prior releases (see
+// dropOptionalExternalEventTimerAt).
+var externalEventIndefiniteFireAt = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)
 
 // Workflow is the functional interface for workflow functions.
 type Workflow func(ctx *WorkflowContext) (any, error)
@@ -545,7 +554,7 @@ func (ctx *WorkflowContext) WaitForSingleEvent(eventName string, timeout time.Du
 		if timeout > 0 {
 			fireAt = ctx.CurrentTimeUtc.Add(timeout)
 		} else {
-			fireAt = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)
+			fireAt = externalEventIndefiniteFireAt
 		}
 		ctx.createExternalEventTimerInternal(eventName, fireAt).onCompleted(func() {
 			task.cancel()
@@ -660,7 +669,15 @@ func (ctx *WorkflowContext) onExecutionStarted(es *protos.ExecutionStartedEvent)
 }
 
 func (ctx *WorkflowContext) onTaskScheduled(taskID int32, ts *protos.TaskScheduledEvent) error {
-	if a, ok := ctx.pendingActions[taskID]; !ok || a.GetScheduleTask() == nil {
+	a, ok := ctx.pendingActions[taskID]
+	if !ok || a.GetScheduleTask() == nil {
+		// Tolerate histories from before WaitForExternalEvent started emitting
+		// a synthetic timer for non-positive timeouts.
+		if ctx.dropOptionalExternalEventTimerAt(taskID) {
+			a, ok = ctx.pendingActions[taskID]
+		}
+	}
+	if !ok || a.GetScheduleTask() == nil {
 		return fmt.Errorf(
 			"a previous execution called CallActivity for '%s' and sequence number %d at this point in the workflow logic, but the current execution doesn't have this action with this sequence number",
 			ts.Name,
@@ -708,7 +725,13 @@ func (ctx *WorkflowContext) onTaskFailed(tf *protos.TaskFailedEvent) error {
 }
 
 func (ctx *WorkflowContext) onChildWorkflowScheduled(taskID int32, ts *protos.ChildWorkflowInstanceCreatedEvent) error {
-	if a, ok := ctx.pendingActions[taskID]; !ok || a.GetCreateChildWorkflow() == nil {
+	a, ok := ctx.pendingActions[taskID]
+	if !ok || a.GetCreateChildWorkflow() == nil {
+		if ctx.dropOptionalExternalEventTimerAt(taskID) {
+			a, ok = ctx.pendingActions[taskID]
+		}
+	}
+	if !ok || a.GetCreateChildWorkflow() == nil {
 		return fmt.Errorf(
 			"a previous execution called CallChildWorkflow for '%s' and sequence number %d at this point in the workflow logic, but the current execution doesn't have this action with this sequence number",
 			ts.Name,
@@ -756,6 +779,16 @@ func (ctx *WorkflowContext) onChildWorkflowFailed(sof *protos.ChildWorkflowInsta
 }
 
 func (ctx *WorkflowContext) onTimerCreated(e *protos.HistoryEvent) error {
+	tc := e.GetTimerCreated()
+	// If the pending action at this position is an optional external-event
+	// timer but the incoming TimerCreated event is something else (e.g. a
+	// real CreateTimer-origin timer emitted by pre-patch code), drop the
+	// optional timer and shift later pending ids down so we match correctly.
+	if a, ok := ctx.pendingActions[e.EventId]; ok &&
+		isOptionalExternalEventTimerAction(a) &&
+		!isOptionalExternalEventTimerCreatedEvent(tc) {
+		ctx.dropOptionalExternalEventTimerAt(e.EventId)
+	}
 	if a, ok := ctx.pendingActions[e.EventId]; !ok || a.GetCreateTimer() == nil {
 		return fmt.Errorf(
 			"a previous execution called CreateTimer with sequence number %d, but the current execution doesn't have this action with this sequence number",
@@ -912,6 +945,89 @@ func (ctx *WorkflowContext) getNextSequenceNumber() int32 {
 	current := ctx.sequenceNumber
 	ctx.sequenceNumber++
 	return current
+}
+
+// isOptionalExternalEventTimerAction reports whether the given pending workflow
+// action is a synthetic timer emitted by WaitForExternalEvent with a
+// non-positive timeout. Such timers were not created by earlier releases and
+// must be dropped when replaying a history produced by one of those releases
+// so sequence-number determinism is preserved.
+func isOptionalExternalEventTimerAction(a *protos.WorkflowAction) bool {
+	if a == nil {
+		return false
+	}
+	ct := a.GetCreateTimer()
+	if ct == nil || ct.GetExternalEvent() == nil {
+		return false
+	}
+	fa := ct.GetFireAt()
+	if fa == nil {
+		return false
+	}
+	return fa.AsTime().Equal(externalEventIndefiniteFireAt)
+}
+
+// isOptionalExternalEventTimerCreatedEvent reports whether a TimerCreated
+// history event was emitted for a synthetic external-event timer. When a
+// TimerCreated event matches both sides (pending action and history event),
+// the replay is of a history already produced by the current release and the
+// optional timer should be matched normally rather than shifted out.
+func isOptionalExternalEventTimerCreatedEvent(tc *protos.TimerCreatedEvent) bool {
+	if tc == nil || tc.GetExternalEvent() == nil {
+		return false
+	}
+	fa := tc.GetFireAt()
+	if fa == nil {
+		return false
+	}
+	return fa.AsTime().Equal(externalEventIndefiniteFireAt)
+}
+
+// dropOptionalExternalEventTimerAt removes the optional pending CreateTimer
+// action/task (if any) at atID and shifts every later pending action and
+// pending task id down by one. This lets the SDK tolerate replaying a
+// history that was produced before WaitForExternalEvent started emitting a
+// synthetic CreateTimer action for non-positive timeouts. Returns true if an
+// optional timer was removed.
+func (ctx *WorkflowContext) dropOptionalExternalEventTimerAt(atID int32) bool {
+	a, ok := ctx.pendingActions[atID]
+	if !ok || !isOptionalExternalEventTimerAction(a) {
+		return false
+	}
+
+	delete(ctx.pendingActions, atID)
+	delete(ctx.pendingTasks, atID)
+
+	// Collect later ids and shift them down, ascending so reinsertion is stable.
+	actionIDs := make([]int32, 0, len(ctx.pendingActions))
+	for id := range ctx.pendingActions {
+		if id > atID {
+			actionIDs = append(actionIDs, id)
+		}
+	}
+	sort.Slice(actionIDs, func(i, j int) bool { return actionIDs[i] < actionIDs[j] })
+	for _, id := range actionIDs {
+		act := ctx.pendingActions[id]
+		delete(ctx.pendingActions, id)
+		act.Id = id - 1
+		ctx.pendingActions[id-1] = act
+	}
+
+	taskIDs := make([]int32, 0, len(ctx.pendingTasks))
+	for id := range ctx.pendingTasks {
+		if id > atID {
+			taskIDs = append(taskIDs, id)
+		}
+	}
+	sort.Slice(taskIDs, func(i, j int) bool { return taskIDs[i] < taskIDs[j] })
+	for _, id := range taskIDs {
+		t := ctx.pendingTasks[id]
+		delete(ctx.pendingTasks, id)
+		ctx.pendingTasks[id-1] = t
+	}
+
+	ctx.sequenceNumber--
+	return true
 }
 
 func (ctx *WorkflowContext) actions() []*protos.WorkflowAction {

--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -22,7 +22,7 @@ import (
 )
 
 // externalEventIndefiniteFireAt is the sentinel fire-at value used for the
-// synthetic timer backing WaitForExternalEvent calls with a non-positive
+// synthetic timer backing WaitForExternalEvent calls with a negative
 // timeout. It is chosen far enough in the future that it effectively never
 // fires, and is used on replay to recognize optional pending timers that
 // may be absent from histories produced by prior releases (see
@@ -672,7 +672,7 @@ func (ctx *WorkflowContext) onTaskScheduled(taskID int32, ts *protos.TaskSchedul
 	a, ok := ctx.pendingActions[taskID]
 	if !ok || a.GetScheduleTask() == nil {
 		// Tolerate histories from before WaitForExternalEvent started emitting
-		// a synthetic timer for non-positive timeouts.
+		// a synthetic timer for negative timeouts.
 		if ctx.dropOptionalExternalEventTimerAt(taskID) {
 			a, ok = ctx.pendingActions[taskID]
 		}
@@ -949,7 +949,7 @@ func (ctx *WorkflowContext) getNextSequenceNumber() int32 {
 
 // isOptionalExternalEventTimerAction reports whether the given pending workflow
 // action is a synthetic timer emitted by WaitForExternalEvent with a
-// non-positive timeout. Such timers were not created by earlier releases and
+// negative timeout. Such timers were not created by earlier releases and
 // must be dropped when replaying a history produced by one of those releases
 // so sequence-number determinism is preserved.
 func isOptionalExternalEventTimerAction(a *protos.WorkflowAction) bool {
@@ -984,10 +984,10 @@ func isOptionalExternalEventTimerCreatedEvent(tc *protos.TimerCreatedEvent) bool
 }
 
 // dropOptionalExternalEventTimerAt removes the optional pending CreateTimer
-// action/task (if any) at atID and shifts every later pending action and
+// action/task (if any) at ID atID and shifts every later pending action and
 // pending task id down by one. This lets the SDK tolerate replaying a
 // history that was produced before WaitForExternalEvent started emitting a
-// synthetic CreateTimer action for non-positive timeouts. Returns true if an
+// synthetic CreateTimer action for negative timeouts. Returns true if an
 // optional timer was removed.
 func (ctx *WorkflowContext) dropOptionalExternalEventTimerAt(atID int32) bool {
 	a, ok := ctx.pendingActions[atID]

--- a/tests/task_executor_test.go
+++ b/tests/task_executor_test.go
@@ -283,3 +283,538 @@ func Test_Executor_SuspendStopsAllActions(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, results.Actions, "Suspended workflows should not have any actions")
 }
+
+// Regression test: replaying a history produced before WaitForSingleEvent
+// started emitting a synthetic CreateTimer action for non-positive timeouts
+// must still be deterministic. In pre-patch histories, an indefinite
+// WaitForSingleEvent left no TimerCreated event behind, so subsequent actions
+// (e.g. CallActivity) carry the lower sequence numbers. The SDK must drop the
+// optional pending timer on replay and shift later pending ids down so
+// TaskScheduled at EventId=0 continues to match the activity.
+func Test_Executor_Replay_PrePatchIndefiniteWaitForEvent(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddActivityN("MyActivity", func(ctx task.ActivityContext) (any, error) {
+		return "ok", nil
+	})
+	r.AddWorkflowN("Orchestration", func(ctx *task.WorkflowContext) (any, error) {
+		var v int
+		if err := ctx.WaitForSingleEvent("MyEvent", -1).Await(&v); err != nil {
+			return nil, err
+		}
+		var out string
+		if err := ctx.CallActivity("MyActivity").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	})
+
+	iid := api.InstanceID("abc123")
+	executionID := uuid.New().String()
+	startTime := time.Now()
+
+	// oldEvents simulate a history produced by a prior release: the indefinite
+	// WaitForSingleEvent consumed no sequence number, so the activity's
+	// TaskScheduled was written with EventId=0.
+	oldEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Orchestration",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(executionID),
+					},
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_EventRaised{
+				EventRaised: &protos.EventRaisedEvent{
+					Name:  "MyEvent",
+					Input: wrapperspb.String("42"),
+				},
+			},
+		},
+		{
+			EventId:   0,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_TaskScheduled{
+				TaskScheduled: &protos.TaskScheduledEvent{
+					Name: "MyActivity",
+				},
+			},
+		},
+	}
+
+	// newEvents: the activity completes with its result.
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_TaskCompleted{
+				TaskCompleted: &protos.TaskCompletedEvent{
+					TaskScheduledId: 0,
+					Result:          wrapperspb.String(`"ok"`),
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, oldEvents, newEvents)
+	require.NoError(t, err, "Replay of pre-patch history must not fail the determinism check")
+	require.Equal(t, 1, len(results.Actions), "Expected a single CompleteWorkflow action after replay")
+
+	complete := results.Actions[0].GetCompleteWorkflow()
+	require.NotNil(t, complete, "Expected CompleteWorkflow action")
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, complete.WorkflowStatus)
+	require.NotNil(t, complete.Result)
+	require.Equal(t, `"ok"`, complete.Result.Value)
+
+	// No optional CreateTimer should leak through: the replay must consume
+	// the optional timer entirely rather than emit it to the backend.
+	for _, a := range results.Actions {
+		require.Nil(t, a.GetCreateTimer(), "Optional CreateTimer must not be emitted on replay of a pre-patch history")
+	}
+}
+
+// Regression test: when replaying a post-patch history where the indefinite
+// WaitForSingleEvent already emitted a TimerCreated(origin=ExternalEvent,
+// fireAt=9999) event, the SDK must match it normally and must NOT drop any
+// pending action. This guards against a too-aggressive shift that would also
+// trigger for histories produced by the current runtime.
+func Test_Executor_Replay_PostPatchIndefiniteWaitForEvent(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddWorkflowN("Orchestration", func(ctx *task.WorkflowContext) (any, error) {
+		var v int
+		if err := ctx.WaitForSingleEvent("MyEvent", -1).Await(&v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	})
+
+	iid := api.InstanceID("abc123")
+	executionID := uuid.New().String()
+	startTime := time.Now()
+	infiniteFireAt := time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)
+
+	// oldEvents simulate a history produced by the current runtime: the
+	// indefinite WaitForSingleEvent emitted its optional timer at EventId=0.
+	oldEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Orchestration",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(executionID),
+					},
+				},
+			},
+		},
+		{
+			EventId:   0,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_TimerCreated{
+				TimerCreated: &protos.TimerCreatedEvent{
+					FireAt: timestamppb.New(infiniteFireAt),
+					Origin: &protos.TimerCreatedEvent_ExternalEvent{
+						ExternalEvent: &protos.TimerOriginExternalEvent{Name: "MyEvent"},
+					},
+				},
+			},
+		},
+	}
+
+	// newEvents: the external event finally arrives.
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_EventRaised{
+				EventRaised: &protos.EventRaisedEvent{
+					Name:  "MyEvent",
+					Input: wrapperspb.String("42"),
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, oldEvents, newEvents)
+	require.NoError(t, err, "Post-patch replay must succeed")
+	require.Equal(t, 1, len(results.Actions), "Expected a single CompleteWorkflow action")
+
+	complete := results.Actions[0].GetCompleteWorkflow()
+	require.NotNil(t, complete)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, complete.WorkflowStatus)
+	require.Equal(t, `42`, complete.Result.Value)
+}
+
+// Regression test: pre-patch history where an indefinite WaitForSingleEvent is
+// followed by CallChildWorkflow. Exercises the onChildWorkflowScheduled shift
+// path (distinct from onTaskScheduled).
+func Test_Executor_Replay_PrePatchIndefiniteWaitForEvent_ChildWorkflow(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddWorkflowN("Child", func(ctx *task.WorkflowContext) (any, error) {
+		return "child-result", nil
+	})
+	r.AddWorkflowN("Parent", func(ctx *task.WorkflowContext) (any, error) {
+		var v int
+		if err := ctx.WaitForSingleEvent("MyEvent", -1).Await(&v); err != nil {
+			return nil, err
+		}
+		var out string
+		if err := ctx.CallChildWorkflow("Child").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	})
+
+	iid := api.InstanceID("parent-1")
+	executionID := uuid.New().String()
+	startTime := time.Now()
+
+	oldEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Parent",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(executionID),
+					},
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_EventRaised{
+				EventRaised: &protos.EventRaisedEvent{
+					Name:  "MyEvent",
+					Input: wrapperspb.String("1"),
+				},
+			},
+		},
+		{
+			EventId:   0,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{
+				ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{
+					InstanceId: "child-1",
+					Name:       "Child",
+				},
+			},
+		},
+	}
+
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+				ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+					TaskScheduledId: 0,
+					Result:          wrapperspb.String(`"child-result"`),
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, oldEvents, newEvents)
+	require.NoError(t, err, "Replay of pre-patch history with a child workflow must not fail")
+	require.Equal(t, 1, len(results.Actions), "Expected a single CompleteWorkflow action")
+
+	complete := results.Actions[0].GetCompleteWorkflow()
+	require.NotNil(t, complete)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, complete.WorkflowStatus)
+	require.Equal(t, `"child-result"`, complete.Result.Value)
+	for _, a := range results.Actions {
+		require.Nil(t, a.GetCreateTimer(), "Optional CreateTimer must not be emitted")
+	}
+}
+
+// Regression test: pre-patch history where an indefinite WaitForSingleEvent is
+// followed by a user CreateTimer. Exercises the onTimerCreated shift path —
+// specifically the "pending is optional, incoming real CreateTimer-origin" case
+// where the incoming TimerCreated is NOT itself optional so the shift must
+// trigger despite both being CreateTimer actions.
+func Test_Executor_Replay_PrePatchIndefiniteWaitForEvent_RealTimer(t *testing.T) {
+	timerDuration := 5 * time.Second
+	r := task.NewTaskRegistry()
+	r.AddWorkflowN("Orchestration", func(ctx *task.WorkflowContext) (any, error) {
+		var v int
+		if err := ctx.WaitForSingleEvent("MyEvent", -1).Await(&v); err != nil {
+			return nil, err
+		}
+		if err := ctx.CreateTimer(timerDuration).Await(nil); err != nil {
+			return nil, err
+		}
+		return v, nil
+	})
+
+	iid := api.InstanceID("abc123")
+	executionID := uuid.New().String()
+	startTime := time.Now()
+
+	oldEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Orchestration",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(executionID),
+					},
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_EventRaised{
+				EventRaised: &protos.EventRaisedEvent{
+					Name:  "MyEvent",
+					Input: wrapperspb.String("7"),
+				},
+			},
+		},
+		{
+			EventId:   0,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_TimerCreated{
+				TimerCreated: &protos.TimerCreatedEvent{
+					FireAt: timestamppb.New(startTime.Add(timerDuration)),
+					Origin: &protos.TimerCreatedEvent_CreateTimer{
+						CreateTimer: &protos.TimerOriginCreateTimer{},
+					},
+				},
+			},
+		},
+	}
+
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime.Add(timerDuration)),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime.Add(timerDuration)),
+			EventType: &protos.HistoryEvent_TimerFired{
+				TimerFired: &protos.TimerFiredEvent{
+					TimerId: 0,
+					FireAt:  timestamppb.New(startTime.Add(timerDuration)),
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, oldEvents, newEvents)
+	require.NoError(t, err, "Replay of pre-patch history with a real timer must not fail")
+	require.Equal(t, 1, len(results.Actions), "Expected a single CompleteWorkflow action")
+
+	complete := results.Actions[0].GetCompleteWorkflow()
+	require.NotNil(t, complete)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, complete.WorkflowStatus)
+	require.Equal(t, `7`, complete.Result.Value)
+	for _, a := range results.Actions {
+		require.Nil(t, a.GetCreateTimer(), "Optional CreateTimer must not be emitted")
+	}
+}
+
+// Regression test: two consecutive indefinite WaitForSingleEvent calls each
+// followed by a CallActivity. In a pre-patch history both activities carry
+// sequence numbers 0 and 1. The runtime must drop two separate optional
+// timers and shift the pending map on each occurrence.
+func Test_Executor_Replay_PrePatchIndefiniteWaitForEvent_Multiple(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddActivityN("ActA", func(ctx task.ActivityContext) (any, error) {
+		return "a", nil
+	})
+	r.AddActivityN("ActB", func(ctx task.ActivityContext) (any, error) {
+		return "b", nil
+	})
+	r.AddWorkflowN("Orchestration", func(ctx *task.WorkflowContext) (any, error) {
+		var v int
+		if err := ctx.WaitForSingleEvent("EventA", -1).Await(&v); err != nil {
+			return nil, err
+		}
+		var outA string
+		if err := ctx.CallActivity("ActA").Await(&outA); err != nil {
+			return nil, err
+		}
+		if err := ctx.WaitForSingleEvent("EventB", -1).Await(&v); err != nil {
+			return nil, err
+		}
+		var outB string
+		if err := ctx.CallActivity("ActB").Await(&outB); err != nil {
+			return nil, err
+		}
+		return outA + outB, nil
+	})
+
+	iid := api.InstanceID("abc123")
+	executionID := uuid.New().String()
+	startTime := time.Now()
+
+	oldEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Orchestration",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(executionID),
+					},
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_EventRaised{
+				EventRaised: &protos.EventRaisedEvent{Name: "EventA", Input: wrapperspb.String("1")},
+			},
+		},
+		{
+			EventId:   0,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_TaskScheduled{
+				TaskScheduled: &protos.TaskScheduledEvent{Name: "ActA"},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_TaskCompleted{
+				TaskCompleted: &protos.TaskCompletedEvent{
+					TaskScheduledId: 0,
+					Result:          wrapperspb.String(`"a"`),
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_EventRaised{
+				EventRaised: &protos.EventRaisedEvent{Name: "EventB", Input: wrapperspb.String("2")},
+			},
+		},
+		{
+			EventId:   1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_TaskScheduled{
+				TaskScheduled: &protos.TaskScheduledEvent{Name: "ActB"},
+			},
+		},
+	}
+
+	// newEvents: second activity completes.
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_TaskCompleted{
+				TaskCompleted: &protos.TaskCompletedEvent{
+					TaskScheduledId: 1,
+					Result:          wrapperspb.String(`"b"`),
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, oldEvents, newEvents)
+	require.NoError(t, err, "Replay of pre-patch history with multiple indefinite waits must not fail")
+	require.Equal(t, 1, len(results.Actions), "Expected a single CompleteWorkflow action")
+
+	complete := results.Actions[0].GetCompleteWorkflow()
+	require.NotNil(t, complete)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, complete.WorkflowStatus)
+	require.Equal(t, `"ab"`, complete.Result.Value)
+	for _, a := range results.Actions {
+		require.Nil(t, a.GetCreateTimer(), "No optional CreateTimer must leak through")
+	}
+}

--- a/tests/task_executor_test.go
+++ b/tests/task_executor_test.go
@@ -285,7 +285,7 @@ func Test_Executor_SuspendStopsAllActions(t *testing.T) {
 }
 
 // Regression test: replaying a history produced before WaitForSingleEvent
-// started emitting a synthetic CreateTimer action for non-positive timeouts
+// started emitting a synthetic CreateTimer action for negative timeouts
 // must still be deterministic. In pre-patch histories, an indefinite
 // WaitForSingleEvent left no TimerCreated event behind, so subsequent actions
 // (e.g. CallActivity) carry the lower sequence numbers. The SDK must drop the


### PR DESCRIPTION
In https://github.com/dapr/durabletask-go/pull/78 I introduced a non-backwards-compatible change, adding a timer for every external events, even for ones with a negative timeout.

Before, workflows with negative timeout didn't create a timer, and now they do, so durabletask would fail when finding out the timer is missing for existing workflows.

This PR makes those timers optional by ignoring them when correlating events and workflow code.