### PR TITLE
Fix Purge and Terminate calls on cross app recursion

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -228,9 +228,13 @@ func purgeWorkflowState(ctx context.Context, be Backend, iid api.InstanceID, rec
 
 // isRemoteRouter reports whether the given router targets a sub-orchestration
 // hosted on a different app, i.e. whether the recursion driver should delegate
-// the entire subtree to the backend's cross-app dispatch path.
+// the entire subtree to the backend's cross-app dispatch path. The applier
+// stamps every action's router with at least SourceAppID, so same-app children
+// arrive here with a non-nil router whose TargetAppID is empty — match on the
+// effective target string to stay aligned with the per-backend dispatch
+// predicates.
 func isRemoteRouter(r *protos.TaskRouter) bool {
-	return r != nil && r.TargetAppID != nil
+	return r.GetTargetAppID() != ""
 }
 
 // childWorkflowRef captures a child workflow's instance ID together with the
@@ -271,7 +275,10 @@ func terminateChildWorkflowInstances(ctx context.Context, be Backend, iid api.In
 
 // getChildWorkflowInstances returns each child workflow recorded in the given
 // events, paired with the router that was attached to its
-// ChildWorkflowInstanceCreated history event (nil for same-app children).
+// ChildWorkflowInstanceCreated history event. The applier always populates a
+// router on emitted history events (at minimum the parent's SourceAppID), so
+// same-app children are represented by a router whose TargetAppID is unset
+// or empty rather than by a nil router.
 func getChildWorkflowInstances(oldEvents []*HistoryEvent, newEvents []*HistoryEvent) []childWorkflowRef {
 	childWorkflowInstancesMap := make(map[api.InstanceID]*protos.TaskRouter, len(oldEvents)+len(newEvents))
 	collect := func(events []*HistoryEvent) {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -116,11 +116,16 @@ type Backend interface {
 	// This is called when an internal failure occurs during activity work-item processing.
 	AbandonActivityWorkItem(context.Context, *ActivityWorkItem) error
 
-	// PurgeWorkflowState deletes all saved state for the specified workflow instance.
-	//
+	// PurgeWorkflowState deletes saved workflow state. When router is nil or
+	// targets the local app, this is a single-instance purge of id and the
+	// returned count is 1 on success. When router carries a foreign TargetAppID
+	// set by the recursive purge driver for a child started cross-app the
+	// backend is expected to delegate the entire recursive purge of that subtree
+	// to the target app (the local recursion stops walking through it) and
+	// return the number of instances purged on the remote side.
 	// [api.ErrInstanceNotFound] is returned if the specified workflow instance doesn't exist.
 	// [api.ErrNotCompleted] is returned if the specified workflow instance is still running.
-	PurgeWorkflowState(ctx context.Context, id api.InstanceID, force bool) error
+	PurgeWorkflowState(ctx context.Context, id api.InstanceID, router *protos.TaskRouter, force bool) (int, error)
 
 	// CompleteWorkflowTask completes the workflow task by saving the updated runtime state to durable storage.
 	CompleteWorkflowTask(context.Context, *protos.WorkflowResponse) error
@@ -191,10 +196,22 @@ func purgeWorkflowState(ctx context.Context, be Backend, iid api.InstanceID, rec
 			return 0, api.ErrNotCompleted
 		}
 		childWorkflowInstances := getChildWorkflowInstances(state.OldEvents, state.NewEvents)
-		for _, childWorkflowInstance := range childWorkflowInstances {
-			// Recursively purge child workflows
-			count, err := purgeWorkflowState(ctx, be, childWorkflowInstance, recursive, force)
-			// `count` child workflows have been successfully purged (even in case of error)
+		for _, child := range childWorkflowInstances {
+			if isRemoteRouter(child.Router) {
+				// Child workflow started cross-app: its state (and any further
+				// descendants) live on a different app, so delegate the entire subtree
+				// to the backend rather than trying to walk it from here.
+				count, err := be.PurgeWorkflowState(ctx, child.InstanceID, child.Router, force)
+				deletedInstanceCount += count
+				if err != nil {
+					return deletedInstanceCount, fmt.Errorf("failed to purge cross-app child workflow: %w", err)
+				}
+				continue
+			}
+			// Same-app child: walk locally.
+			count, err := purgeWorkflowState(ctx, be, child.InstanceID, recursive, force)
+			// `count` child workflows have been successfully purged (even in case of
+			// error)
 			deletedInstanceCount += count
 			if err != nil {
 				return deletedInstanceCount, fmt.Errorf("failed to purge child workflow: %w", err)
@@ -202,10 +219,28 @@ func purgeWorkflowState(ctx context.Context, be Backend, iid api.InstanceID, rec
 		}
 	}
 	// Purging root workflow
-	if err := be.PurgeWorkflowState(ctx, iid, force); err != nil {
+	count, err := be.PurgeWorkflowState(ctx, iid, nil, force)
+	if err != nil {
 		return deletedInstanceCount, err
 	}
-	return deletedInstanceCount + 1, nil
+	return deletedInstanceCount + count, nil
+}
+
+// isRemoteRouter reports whether the given router targets a sub-orchestration
+// hosted on a different app, i.e. whether the recursion driver should delegate
+// the entire subtree to the backend's cross-app dispatch path.
+func isRemoteRouter(r *protos.TaskRouter) bool {
+	return r != nil && r.TargetAppID != nil
+}
+
+// childWorkflowRef captures a child workflow's instance ID together with the
+// routing metadata recorded on its ChildWorkflowInstanceCreated history event.
+// The router carries the target app ID for cross-app sub-orchestrations and
+// must be preserved when synthesising new events (e.g. recursive terminate) so
+// the backend can dispatch them to the correct app.
+type childWorkflowRef struct {
+	InstanceID api.InstanceID
+	Router     *protos.TaskRouter
 }
 
 // terminateChildWorkflowInstances submits termination requests to child workflows if [et.Recurse] is true.
@@ -214,7 +249,7 @@ func terminateChildWorkflowInstances(ctx context.Context, be Backend, iid api.In
 		return nil
 	}
 	childWorkflowInstances := getChildWorkflowInstances(state.OldEvents, state.NewEvents)
-	for _, childWorkflowInstance := range childWorkflowInstances {
+	for _, child := range childWorkflowInstances {
 		e := &protos.HistoryEvent{
 			EventId:   -1,
 			Timestamp: timestamppb.Now(),
@@ -224,40 +259,43 @@ func terminateChildWorkflowInstances(ctx context.Context, be Backend, iid api.In
 					Recurse: et.Recurse,
 				},
 			},
+			Router: child.Router,
 		}
 		// Adding terminate event to child workflow instance
-		if err := be.AddNewWorkflowEvent(ctx, childWorkflowInstance, e); err != nil {
+		if err := be.AddNewWorkflowEvent(ctx, child.InstanceID, e); err != nil {
 			return fmt.Errorf("failed to submit termination request to child workflow: %w", err)
 		}
 	}
 	return nil
 }
 
-// getChildWorkflowInstances returns the instance IDs of all child workflows
-// in the specified events. Children scheduled with a cross-namespace router
-// are excluded: their state lives on a different sidecar and recursive
-// termination of them through this backend would fail with "no such
-// instance exists". The host (dapr) is responsible for delivering a
-// cross-namespace terminate hop when needed.
-func getChildWorkflowInstances(oldEvents []*HistoryEvent, newEvents []*HistoryEvent) []api.InstanceID {
-	childWorkflowInstancesMap := make(map[api.InstanceID]struct{}, len(oldEvents)+len(newEvents))
+// getChildWorkflowInstances returns each child workflow recorded in the given
+// events, paired with the router that was attached to its
+// ChildWorkflowInstanceCreated history event (nil for same-app children).
+func getChildWorkflowInstances(oldEvents []*HistoryEvent, newEvents []*HistoryEvent) []childWorkflowRef {
+	childWorkflowInstancesMap := make(map[api.InstanceID]*protos.TaskRouter, len(oldEvents)+len(newEvents))
 	collect := func(events []*HistoryEvent) {
 		for _, e := range events {
 			created := e.GetChildWorkflowInstanceCreated()
 			if created == nil {
 				continue
 			}
-			if router := e.GetRouter(); router != nil && router.TargetAppNamespace != nil {
+			id := api.InstanceID(created.InstanceId)
+			if _, ok := childWorkflowInstancesMap[id]; ok {
 				continue
 			}
-			childWorkflowInstancesMap[api.InstanceID(created.InstanceId)] = struct{}{}
+			childWorkflowInstancesMap[id] = e.GetRouter()
 		}
 	}
 	collect(oldEvents)
 	collect(newEvents)
-	childWorkflowInstances := make([]api.InstanceID, 0, len(childWorkflowInstancesMap))
-	for orch := range childWorkflowInstancesMap {
-		childWorkflowInstances = append(childWorkflowInstances, orch)
+
+	childWorkflowInstances := make([]childWorkflowRef, 0, len(childWorkflowInstancesMap))
+	for id, router := range childWorkflowInstancesMap {
+		childWorkflowInstances = append(childWorkflowInstances, childWorkflowRef{
+			InstanceID: id,
+			Router:     router,
+		})
 	}
 	return childWorkflowInstances
 }

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -44,12 +44,12 @@ func childCreatedEvent(instanceID string, targetAppNamespace *string) *HistoryEv
 	}
 }
 
-// TestGetChildWorkflowInstances_SkipsCrossNamespace asserts that recursive
-// terminate enumeration excludes children scheduled with a router that
-// targets another namespace. Their state lives on a different sidecar; the
-// local backend can't terminate them and the host (dapr) handles
-// cross-namespace terminate dispatch separately.
-func TestGetChildWorkflowInstances_SkipsCrossNamespace(t *testing.T) {
+// TestGetChildWorkflowInstances_PreservesCrossNamespaceRouter asserts that
+// cross-namespace children are enumerated and that the router recorded on
+// their ChildWorkflowInstanceCreated event is preserved on the returned ref.
+// The caller relies on the router to dispatch the recursive terminate to the
+// correct sidecar.
+func TestGetChildWorkflowInstances_PreservesCrossNamespaceRouter(t *testing.T) {
 	old := []*HistoryEvent{
 		childCreatedEvent("local-old", nil),
 		childCreatedEvent("xns-old", ptr.Of("other-ns")),
@@ -60,21 +60,26 @@ func TestGetChildWorkflowInstances_SkipsCrossNamespace(t *testing.T) {
 	}
 
 	got := getChildWorkflowInstances(old, newEvts)
-	gotSet := make(map[api.InstanceID]struct{}, len(got))
-	for _, id := range got {
-		gotSet[id] = struct{}{}
+	gotMap := make(map[api.InstanceID]*protos.TaskRouter, len(got))
+	for _, child := range got {
+		gotMap[child.InstanceID] = child.Router
 	}
 
-	require.Len(t, got, 2, "only local children should be enumerated")
-	assert.Contains(t, gotSet, api.InstanceID("local-old"))
-	assert.Contains(t, gotSet, api.InstanceID("local-new"))
-	assert.NotContains(t, gotSet, api.InstanceID("xns-old"))
-	assert.NotContains(t, gotSet, api.InstanceID("xns-new"))
+	require.Len(t, got, 4, "all children should be enumerated regardless of router")
+	assert.Contains(t, gotMap, api.InstanceID("local-old"))
+	assert.Contains(t, gotMap, api.InstanceID("local-new"))
+	assert.Contains(t, gotMap, api.InstanceID("xns-old"))
+	assert.Contains(t, gotMap, api.InstanceID("xns-new"))
+
+	require.NotNil(t, gotMap[api.InstanceID("xns-old")])
+	assert.Equal(t, "other-ns", gotMap[api.InstanceID("xns-old")].GetTargetAppNamespace())
+	require.NotNil(t, gotMap[api.InstanceID("xns-new")])
+	assert.Equal(t, "other-ns", gotMap[api.InstanceID("xns-new")].GetTargetAppNamespace())
 }
 
 // TestGetChildWorkflowInstances_NoRouterTreatedAsLocal confirms that a
 // ChildWorkflowInstanceCreated event with no router (i.e. legacy/same-app
-// scheduling) is enumerated as a local child.
+// scheduling) is enumerated as a local child with a nil router.
 func TestGetChildWorkflowInstances_NoRouterTreatedAsLocal(t *testing.T) {
 	e := &HistoryEvent{
 		EventId:   1,
@@ -88,13 +93,13 @@ func TestGetChildWorkflowInstances_NoRouterTreatedAsLocal(t *testing.T) {
 	}
 	got := getChildWorkflowInstances(nil, []*HistoryEvent{e})
 	require.Len(t, got, 1)
-	assert.Equal(t, api.InstanceID("no-router-child"), got[0])
+	assert.Equal(t, api.InstanceID("no-router-child"), got[0].InstanceID)
+	assert.Nil(t, got[0].Router)
 }
 
 // TestGetChildWorkflowInstances_RouterWithoutNamespaceIsLocal asserts that a
 // router carrying a target appID but no target namespace (cross-app
-// invocation, same-namespace) is still enumerated as a local child for
-// recursive terminate.
+// invocation, same-namespace) is enumerated and its router preserved.
 func TestGetChildWorkflowInstances_RouterWithoutNamespaceIsLocal(t *testing.T) {
 	e := &HistoryEvent{
 		EventId:   1,
@@ -108,7 +113,9 @@ func TestGetChildWorkflowInstances_RouterWithoutNamespaceIsLocal(t *testing.T) {
 	}
 	got := getChildWorkflowInstances(nil, []*HistoryEvent{e})
 	require.Len(t, got, 1)
-	assert.Equal(t, api.InstanceID("cross-app-child"), got[0])
+	assert.Equal(t, api.InstanceID("cross-app-child"), got[0].InstanceID)
+	require.NotNil(t, got[0].Router)
+	assert.Equal(t, "other-app", got[0].Router.GetTargetAppID())
 }
 
 // TestGetChildWorkflowInstances_Deduplicates sanity-checks that a child
@@ -117,5 +124,5 @@ func TestGetChildWorkflowInstances_Deduplicates(t *testing.T) {
 	dup := childCreatedEvent("dup", nil)
 	got := getChildWorkflowInstances([]*HistoryEvent{dup}, []*HistoryEvent{dup})
 	require.Len(t, got, 1)
-	assert.Equal(t, api.InstanceID("dup"), got[0])
+	assert.Equal(t, api.InstanceID("dup"), got[0].InstanceID)
 }

--- a/backend/postgres/postgres.go
+++ b/backend/postgres/postgres.go
@@ -1089,7 +1089,22 @@ func (be *postgresBackend) AbandonActivityWorkItem(ctx context.Context, wi *back
 	return nil
 }
 
-func (be *postgresBackend) PurgeWorkflowState(ctx context.Context, id api.InstanceID, force bool) error {
+// PurgeWorkflowState implements backend.Backend.
+//
+// Postgres does not model cross-app routing — a foreign router from a
+// recursive purge driver indicates a configuration mismatch. Return an error
+// in that case so the caller fails loudly.
+func (be *postgresBackend) PurgeWorkflowState(ctx context.Context, id api.InstanceID, router *protos.TaskRouter, force bool) (int, error) {
+	if router != nil && router.GetTargetAppID() != "" {
+		return 0, errors.New("postgres backend does not support cross-app recursive purge dispatch")
+	}
+	if err := be.purgeWorkflowStateLocal(ctx, id, force); err != nil {
+		return 0, err
+	}
+	return 1, nil
+}
+
+func (be *postgresBackend) purgeWorkflowStateLocal(ctx context.Context, id api.InstanceID, force bool) error {
 	if err := be.ensureDB(); err != nil {
 		return err
 	}

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -1026,7 +1026,22 @@ func (be *sqliteBackend) AbandonActivityWorkItem(ctx context.Context, wi *backen
 	return nil
 }
 
-func (be *sqliteBackend) PurgeWorkflowState(ctx context.Context, id api.InstanceID, force bool) error {
+// PurgeWorkflowState implements backend.Backend.
+//
+// SQLite does not model cross-app routing — a foreign router from a
+// recursive purge driver indicates a configuration mismatch. Return an error
+// in that case so the caller fails loudly.
+func (be *sqliteBackend) PurgeWorkflowState(ctx context.Context, id api.InstanceID, router *protos.TaskRouter, force bool) (int, error) {
+	if router != nil && router.GetTargetAppID() != "" {
+		return 0, errors.New("sqlite backend does not support cross-app recursive purge dispatch")
+	}
+	if err := be.purgeWorkflowStateLocal(ctx, id, force); err != nil {
+		return 0, err
+	}
+	return 1, nil
+}
+
+func (be *sqliteBackend) purgeWorkflowStateLocal(ctx context.Context, id api.InstanceID, force bool) error {
 	if err := be.ensureDB(); err != nil {
 		return err
 	}

--- a/tests/backend_test.go
+++ b/tests/backend_test.go
@@ -393,7 +393,7 @@ func Test_PurgeWorkflowState(t *testing.T) {
 		workItemProcessingTestLogic(t, be, getWorkflowActions, validateMetadata)
 
 		// Purge the workflow state
-		if err := be.PurgeWorkflowState(ctx, instanceID, false); !assert.NoError(t, err) {
+		if _, err := be.PurgeWorkflowState(ctx, instanceID, nil, false); !assert.NoError(t, err) {
 			return
 		}
 
@@ -411,7 +411,7 @@ func Test_PurgeWorkflowState(t *testing.T) {
 		assert.Equal(t, 0, len(state.OldEvents))
 
 		// Attempting to purge again should fail with api.ErrInstanceNotFound
-		if err := be.PurgeWorkflowState(ctx, instanceID, false); !assert.ErrorIs(t, err, api.ErrInstanceNotFound) {
+		if _, err := be.PurgeWorkflowState(ctx, instanceID, nil, false); !assert.ErrorIs(t, err, api.ErrInstanceNotFound) {
 			return
 		}
 	}

--- a/tests/mocks/Backend.go
+++ b/tests/mocks/Backend.go
@@ -942,22 +942,32 @@ func (_c *Backend_NextWorkflowWorkItem_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
-// PurgeWorkflowState provides a mock function with given fields: ctx, id, force
-func (_m *Backend) PurgeWorkflowState(ctx context.Context, id api.InstanceID, force bool) error {
-	ret := _m.Called(ctx, id, force)
+// PurgeWorkflowState provides a mock function with given fields: ctx, id, router, force
+func (_m *Backend) PurgeWorkflowState(ctx context.Context, id api.InstanceID, router *protos.TaskRouter, force bool) (int, error) {
+	ret := _m.Called(ctx, id, router, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PurgeWorkflowState")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, api.InstanceID, bool) error); ok {
-		r0 = rf(ctx, id, force)
+	var r0 int
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, api.InstanceID, *protos.TaskRouter, bool) (int, error)); ok {
+		return rf(ctx, id, router, force)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, api.InstanceID, *protos.TaskRouter, bool) int); ok {
+		r0 = rf(ctx, id, router, force)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(int)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, api.InstanceID, *protos.TaskRouter, bool) error); ok {
+		r1 = rf(ctx, id, router, force)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Backend_PurgeWorkflowState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PurgeWorkflowState'
@@ -968,24 +978,25 @@ type Backend_PurgeWorkflowState_Call struct {
 // PurgeWorkflowState is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id api.InstanceID
+//   - router *protos.TaskRouter
 //   - force bool
-func (_e *Backend_Expecter) PurgeWorkflowState(ctx interface{}, id interface{}, force interface{}) *Backend_PurgeWorkflowState_Call {
-	return &Backend_PurgeWorkflowState_Call{Call: _e.mock.On("PurgeWorkflowState", ctx, id, force)}
+func (_e *Backend_Expecter) PurgeWorkflowState(ctx interface{}, id interface{}, router interface{}, force interface{}) *Backend_PurgeWorkflowState_Call {
+	return &Backend_PurgeWorkflowState_Call{Call: _e.mock.On("PurgeWorkflowState", ctx, id, router, force)}
 }
 
-func (_c *Backend_PurgeWorkflowState_Call) Run(run func(ctx context.Context, id api.InstanceID, force bool)) *Backend_PurgeWorkflowState_Call {
+func (_c *Backend_PurgeWorkflowState_Call) Run(run func(ctx context.Context, id api.InstanceID, router *protos.TaskRouter, force bool)) *Backend_PurgeWorkflowState_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(api.InstanceID), args[2].(bool))
+		run(args[0].(context.Context), args[1].(api.InstanceID), args[2].(*protos.TaskRouter), args[3].(bool))
 	})
 	return _c
 }
 
-func (_c *Backend_PurgeWorkflowState_Call) Return(_a0 error) *Backend_PurgeWorkflowState_Call {
-	_c.Call.Return(_a0)
+func (_c *Backend_PurgeWorkflowState_Call) Return(_a0 int, _a1 error) *Backend_PurgeWorkflowState_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *Backend_PurgeWorkflowState_Call) RunAndReturn(run func(context.Context, api.InstanceID, bool) error) *Backend_PurgeWorkflowState_Call {
+func (_c *Backend_PurgeWorkflowState_Call) RunAndReturn(run func(context.Context, api.InstanceID, *protos.TaskRouter, bool) (int, error)) *Backend_PurgeWorkflowState_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Recursive terminate and recursive purge of a workflow with cross-app child workflows were broken: the recursion driver fanned out to children on the parent's local backend, so calls intended for child workflows hosted on a different app either looped forever ("no such instance" retries on terminate) or failed outright ("instance not found" on purge).

This change threads the child's hosting-app router through the recursion so the backend can delegate cross-app subtrees to the target app, mirroring the existing cross-app start path: