### PR TITLE
Purge: Make recursive purge idempotent

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -206,6 +206,11 @@ func purgeWorkflowState(ctx context.Context, be Backend, iid api.InstanceID, rec
 				// to the backend rather than trying to walk it from here.
 				count, err := be.PurgeWorkflowState(ctx, child.InstanceID, child.Router, force)
 				deletedInstanceCount += count
+				if errors.Is(err, api.ErrInstanceNotFound) {
+					// Child was already purged out-of-band; skip and continue so
+					// recursive purge stays idempotent against partial deletions.
+					continue
+				}
 				if err != nil {
 					return deletedInstanceCount, fmt.Errorf("failed to purge cross-app child workflow: %w", err)
 				}
@@ -216,6 +221,9 @@ func purgeWorkflowState(ctx context.Context, be Backend, iid api.InstanceID, rec
 			// `count` child workflows have been successfully purged (even in case of
 			// error)
 			deletedInstanceCount += count
+			if errors.Is(err, api.ErrInstanceNotFound) {
+				continue
+			}
 			if err != nil {
 				return deletedInstanceCount, fmt.Errorf("failed to purge child workflow: %w", err)
 			}

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -14,6 +14,8 @@ limitations under the License.
 package backend
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,4 +127,177 @@ func TestGetChildWorkflowInstances_Deduplicates(t *testing.T) {
 	got := getChildWorkflowInstances([]*HistoryEvent{dup}, []*HistoryEvent{dup})
 	require.Len(t, got, 1)
 	assert.Equal(t, api.InstanceID("dup"), got[0].InstanceID)
+}
+
+// fakePurgeBackend is a partial Backend used by purgeWorkflowState tests.
+// Methods other than GetWorkflowRuntimeState/PurgeWorkflowState panic via the
+// nil embedded interface so an accidental new dependency surfaces loudly.
+type fakePurgeBackend struct {
+	Backend
+
+	// states keyed by instance ID. A nil entry models "purged out-of-band":
+	// runtime state with no events, which is how the recursive driver
+	// detects [api.ErrInstanceNotFound] for same-app children.
+	states map[api.InstanceID]*protos.WorkflowRuntimeState
+
+	// purgeResults keyed by instance ID maps to (count, error). Records what
+	// be.PurgeWorkflowState should return for each instance. Used by the
+	// recursive driver for both cross-app children (via the router branch)
+	// and the root.
+	purgeResults map[api.InstanceID]struct {
+		count int
+		err   error
+	}
+
+	// purgeCalls records the order of be.PurgeWorkflowState calls for
+	// assertions on dispatch order.
+	purgeCalls []api.InstanceID
+}
+
+func (f *fakePurgeBackend) GetWorkflowRuntimeState(_ context.Context, wi *WorkflowWorkItem) (*protos.WorkflowRuntimeState, error) {
+	s, ok := f.states[wi.InstanceID]
+	if !ok || s == nil {
+		// Empty state mirrors what real backends return for a purged
+		// instance: no events, no completed event.
+		return &protos.WorkflowRuntimeState{InstanceId: string(wi.InstanceID)}, nil
+	}
+	return s, nil
+}
+
+func (f *fakePurgeBackend) PurgeWorkflowState(_ context.Context, id api.InstanceID, _ *protos.TaskRouter, _ bool) (int, error) {
+	f.purgeCalls = append(f.purgeCalls, id)
+	r, ok := f.purgeResults[id]
+	if !ok {
+		return 1, nil
+	}
+	return r.count, r.err
+}
+
+// completedStateWithChildren builds a runtime state that
+// [runtimestate.IsCompleted] returns true for and that exposes the given
+// children via [getChildWorkflowInstances].
+func completedStateWithChildren(instanceID string, children ...*HistoryEvent) *protos.WorkflowRuntimeState {
+	s := &protos.WorkflowRuntimeState{
+		InstanceId: instanceID,
+		NewEvents:  children,
+		CompletedEvent: &protos.ExecutionCompletedEvent{
+			WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+		},
+	}
+	return s
+}
+
+// TestPurgeWorkflowState_Recursive_SkipsMissingSameAppChild asserts that a
+// recursive purge does not abort when a same-app child has already been
+// purged out-of-band. The driver must continue and still purge the parent.
+func TestPurgeWorkflowState_Recursive_SkipsMissingSameAppChild(t *testing.T) {
+	const (
+		parentID = api.InstanceID("parent")
+		childID  = api.InstanceID("missing-child")
+	)
+
+	be := &fakePurgeBackend{
+		states: map[api.InstanceID]*protos.WorkflowRuntimeState{
+			parentID: completedStateWithChildren(string(parentID), childCreatedEvent(string(childID), nil)),
+			// childID intentionally absent: GetWorkflowRuntimeState returns a
+			// state with no events so the recursive driver hits the
+			// ErrInstanceNotFound branch for the child.
+		},
+		purgeResults: map[api.InstanceID]struct {
+			count int
+			err   error
+		}{
+			parentID: {count: 1, err: nil},
+		},
+	}
+
+	count, err := purgeWorkflowState(t.Context(), be, parentID, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "parent must still be purged when child is already gone")
+	assert.Equal(t, []api.InstanceID{parentID}, be.purgeCalls,
+		"only the parent should reach be.PurgeWorkflowState; the missing child short-circuits before the cross-app/local backend call")
+}
+
+// TestPurgeWorkflowState_Recursive_SkipsMissingCrossAppChild asserts that the
+// driver swallows api.ErrInstanceNotFound returned from the backend's
+// cross-app dispatch and continues to purge the parent. This is the case the
+// dapr backend hits when a remote app's recursive purge handler reports the
+// child as already purged.
+func TestPurgeWorkflowState_Recursive_SkipsMissingCrossAppChild(t *testing.T) {
+	const (
+		parentID = api.InstanceID("parent")
+		childID  = api.InstanceID("xapp-child")
+	)
+
+	xappChild := &HistoryEvent{
+		EventId:   1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{
+			ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{
+				InstanceId: string(childID),
+			},
+		},
+		Router: &protos.TaskRouter{TargetAppID: ptr.Of("other-app")},
+	}
+
+	be := &fakePurgeBackend{
+		states: map[api.InstanceID]*protos.WorkflowRuntimeState{
+			parentID: completedStateWithChildren(string(parentID), xappChild),
+		},
+		purgeResults: map[api.InstanceID]struct {
+			count int
+			err   error
+		}{
+			childID:  {count: 0, err: api.ErrInstanceNotFound},
+			parentID: {count: 1, err: nil},
+		},
+	}
+
+	count, err := purgeWorkflowState(t.Context(), be, parentID, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "deleted count should reflect only the parent; the missing child contributes 0")
+	assert.Equal(t, []api.InstanceID{childID, parentID}, be.purgeCalls,
+		"driver should attempt the cross-app child purge before purging the parent")
+}
+
+// TestPurgeWorkflowState_Recursive_PropagatesNonNotFoundChildError ensures
+// the idempotency carve-out only covers ErrInstanceNotFound. Any other error
+// from a child purge must abort the recursion so callers learn about real
+// failures.
+func TestPurgeWorkflowState_Recursive_PropagatesNonNotFoundChildError(t *testing.T) {
+	const (
+		parentID = api.InstanceID("parent")
+		childID  = api.InstanceID("xapp-child")
+	)
+
+	xappChild := &HistoryEvent{
+		EventId:   1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{
+			ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{
+				InstanceId: string(childID),
+			},
+		},
+		Router: &protos.TaskRouter{TargetAppID: ptr.Of("other-app")},
+	}
+
+	boom := errors.New("backend exploded")
+	be := &fakePurgeBackend{
+		states: map[api.InstanceID]*protos.WorkflowRuntimeState{
+			parentID: completedStateWithChildren(string(parentID), xappChild),
+		},
+		purgeResults: map[api.InstanceID]struct {
+			count int
+			err   error
+		}{
+			childID: {count: 0, err: boom},
+		},
+	}
+
+	count, err := purgeWorkflowState(t.Context(), be, parentID, true, false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+	assert.Equal(t, 0, count)
+	assert.Equal(t, []api.InstanceID{childID}, be.purgeCalls,
+		"driver must abort before attempting to purge the parent on a non-NotFound child error")
 }


### PR DESCRIPTION
Swallow instance ID does not exist errors on recursive purge to ensure idempotency.