### PR TITLE
[0.11] runtimestate: dedup task-resolution events by correlator

### DIFF
--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -192,8 +192,9 @@ func (w *orchestratorProcessor) applyWorkItem(ctx context.Context, wi *Orchestra
 	// New events from the work item are appended to the orchestration state, with duplicates automatically
 	// filtered out. If all events are filtered out, return false so that the caller knows not to execute
 	// the orchestration logic for an empty set of events.
-	for _, e := range wi.NewEvents {
-		if err := runtimestate.AddEvent(wi.State, e); err != nil {
+	errs := runtimestate.AddEvents(wi.State, wi.NewEvents)
+	for i, e := range wi.NewEvents {
+		if err := errs[i]; err != nil {
 			if err == runtimestate.ErrDuplicateEvent {
 				w.logger.Warnf("%v: dropping duplicate event: %v", wi.InstanceID, e)
 			} else {

--- a/backend/runtimestate/dedup/dedup_test.go
+++ b/backend/runtimestate/dedup/dedup_test.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dedup_test
 
 import (

--- a/backend/runtimestate/dedup/dedup_test.go
+++ b/backend/runtimestate/dedup/dedup_test.go
@@ -1,0 +1,163 @@
+package dedup_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/runtimestate"
+	"github.com/dapr/durabletask-go/backend/runtimestate/dedup"
+)
+
+func taskCompleted(id int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   id,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: id},
+		},
+	}
+}
+
+func taskFailed(id int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   id,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskFailed{
+			TaskFailed: &protos.TaskFailedEvent{TaskScheduledId: id},
+		},
+	}
+}
+
+func timerFired(id int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   id,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TimerFired{
+			TimerFired: &protos.TimerFiredEvent{TimerId: id},
+		},
+	}
+}
+
+func TestOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		event    *protos.HistoryEvent
+		wantKind dedup.Kind
+		wantID   int32
+		wantOK   bool
+	}{
+		{"TaskCompleted", taskCompleted(7), dedup.KindTask, 7, true},
+		{"TaskFailed shares Task kind", taskFailed(7), dedup.KindTask, 7, true},
+		{"TimerFired", timerFired(3), dedup.KindTimer, 3, true},
+		{
+			"ExecutionStarted has no resolution",
+			&protos.HistoryEvent{EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{Name: "n"},
+			}},
+			dedup.KindNone, 0, false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			k, id, ok := dedup.Of(tt.event)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantKind, k)
+			assert.Equal(t, tt.wantID, id)
+		})
+	}
+}
+
+func TestSet_AddObserve(t *testing.T) {
+	t.Parallel()
+
+	s := dedup.New(0)
+
+	assert.False(t, s.Has(dedup.KindTask, 1))
+	assert.False(t, s.Add(dedup.KindTask, 1), "first add should not be a duplicate")
+	assert.True(t, s.Has(dedup.KindTask, 1))
+	assert.True(t, s.Add(dedup.KindTask, 1), "second add of same key is a duplicate")
+
+	// Same id under a different kind is independent.
+	assert.False(t, s.Add(dedup.KindTimer, 1))
+	assert.True(t, s.Has(dedup.KindTimer, 1))
+
+	// Observe is the event-shaped variant.
+	assert.False(t, s.Observe(taskCompleted(2)))
+	assert.True(t, s.Observe(taskCompleted(2)))
+	// TaskFailed for the same id collides via the shared Task kind.
+	assert.True(t, s.Observe(taskFailed(2)))
+}
+
+func TestSet_NilSentinel(t *testing.T) {
+	t.Parallel()
+
+	var s dedup.Set
+	assert.False(t, s.Has(dedup.KindTask, 1))
+	assert.False(t, s.Add(dedup.KindTask, 1))
+	assert.False(t, s.Observe(taskCompleted(1)))
+}
+
+func TestNewForState_PrePopulates(t *testing.T) {
+	t.Parallel()
+
+	state := runtimestate.NewOrchestrationRuntimeState("inst", nil, []*protos.HistoryEvent{
+		{EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{Name: "wf"},
+		}, Timestamp: timestamppb.Now()},
+		taskCompleted(1),
+		timerFired(2),
+	})
+
+	s := dedup.NewForState(state)
+	assert.True(t, s.Has(dedup.KindTask, 1))
+	assert.True(t, s.Has(dedup.KindTimer, 2))
+	assert.False(t, s.Has(dedup.KindTask, 99))
+}
+
+func TestIsPresent(t *testing.T) {
+	t.Parallel()
+
+	events := []*protos.HistoryEvent{
+		taskCompleted(1),
+		timerFired(5),
+		taskFailed(2),
+	}
+
+	assert.True(t, dedup.IsPresent(events, dedup.KindTask, 1))
+	assert.True(t, dedup.IsPresent(events, dedup.KindTask, 2), "TaskFailed satisfies KindTask presence")
+	assert.True(t, dedup.IsPresent(events, dedup.KindTimer, 5))
+	assert.False(t, dedup.IsPresent(events, dedup.KindTimer, 1), "different kind, same id is not a match")
+	assert.False(t, dedup.IsPresent(events, dedup.KindTask, 999))
+}
+
+func BenchmarkLoadHistory(b *testing.B) {
+	for _, n := range []int{100, 1000, 5000} {
+		history := make([]*protos.HistoryEvent, 0, n+1)
+		history = append(history, &protos.HistoryEvent{
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{Name: "wf"},
+			},
+			Timestamp: timestamppb.Now(),
+		})
+		for i := 0; i < n; i++ {
+			history = append(history, taskCompleted(int32(i)))
+		}
+
+		b.Run("N="+strconv.Itoa(n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = runtimestate.NewOrchestrationRuntimeState("inst", wrapperspb.String(""), history)
+			}
+		})
+	}
+}

--- a/backend/runtimestate/dedup/dedup_test.go
+++ b/backend/runtimestate/dedup/dedup_test.go
@@ -77,7 +77,7 @@ func TestOf(t *testing.T) {
 	}
 }
 
-func TestSet_AddObserve(t *testing.T) {
+func TestSet_Add(t *testing.T) {
 	t.Parallel()
 
 	s := dedup.New(0)
@@ -90,12 +90,6 @@ func TestSet_AddObserve(t *testing.T) {
 	// Same id under a different kind is independent.
 	assert.False(t, s.Add(dedup.KindTimer, 1))
 	assert.True(t, s.Has(dedup.KindTimer, 1))
-
-	// Observe is the event-shaped variant.
-	assert.False(t, s.Observe(taskCompleted(2)))
-	assert.True(t, s.Observe(taskCompleted(2)))
-	// TaskFailed for the same id collides via the shared Task kind.
-	assert.True(t, s.Observe(taskFailed(2)))
 }
 
 func TestSet_NilSentinel(t *testing.T) {
@@ -104,7 +98,6 @@ func TestSet_NilSentinel(t *testing.T) {
 	var s dedup.Set
 	assert.False(t, s.Has(dedup.KindTask, 1))
 	assert.False(t, s.Add(dedup.KindTask, 1))
-	assert.False(t, s.Observe(taskCompleted(1)))
 }
 
 func TestNewForState_PrePopulates(t *testing.T) {

--- a/backend/runtimestate/dedup/internal_test.go
+++ b/backend/runtimestate/dedup/internal_test.go
@@ -1,0 +1,26 @@
+package dedup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackKey_DistinctKindsDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	kinds := []Kind{KindNone, KindTask, KindTimer, KindChild}
+	ids := []int32{0, 1, -1, 7, 1<<31 - 1, -1 << 31}
+
+	seen := make(map[setKey]struct{}, len(kinds)*len(ids))
+	for _, k := range kinds {
+		for _, id := range ids {
+			pk := packKey(k, id)
+			if _, dup := seen[pk]; dup {
+				t.Fatalf("packKey collision for (%v, %d) -> %d", k, id, pk)
+			}
+			seen[pk] = struct{}{}
+		}
+	}
+	assert.Len(t, seen, len(kinds)*len(ids))
+}

--- a/backend/runtimestate/dedup/internal_test.go
+++ b/backend/runtimestate/dedup/internal_test.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dedup
 
 import (

--- a/backend/runtimestate/dedup/key.go
+++ b/backend/runtimestate/dedup/key.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package dedup detects duplicate task-resolution events
 // (TaskCompleted/TaskFailed/TimerFired/SubOrchestrationInstance{Completed,Failed})
 // inside an orchestration's runtime state.

--- a/backend/runtimestate/dedup/key.go
+++ b/backend/runtimestate/dedup/key.go
@@ -1,0 +1,51 @@
+// Package dedup detects duplicate task-resolution events
+// (TaskCompleted/TaskFailed/TimerFired/ChildWorkflowInstance{Completed,Failed})
+// inside a workflow's runtime state.
+package dedup
+
+import "github.com/dapr/durabletask-go/api/protos"
+
+// Kind names the family of correlator that identifies a task-resolution event.
+// Two events are duplicates only when they share both kind and id.
+type Kind uint8
+
+const (
+	KindNone Kind = iota
+	// KindTask covers TaskCompleted and TaskFailed, both correlated by
+	// TaskScheduledId. A failure arriving after a completion (or vice versa) for
+	// the same id is still a duplicate.
+	KindTask
+	KindTimer
+	// KindChild covers ChildWorkflowInstanceCompleted and
+	// ChildWorkflowInstanceFailed, correlated by TaskScheduledId.
+	KindChild
+)
+
+// Of returns the (kind, id) correlator for e. Returns (KindNone, 0, false)
+// for events with no resolution semantics.
+func Of(e *protos.HistoryEvent) (Kind, int32, bool) {
+	switch {
+	case e.GetTaskCompleted() != nil:
+		return KindTask, e.GetTaskCompleted().GetTaskScheduledId(), true
+	case e.GetTaskFailed() != nil:
+		return KindTask, e.GetTaskFailed().GetTaskScheduledId(), true
+	case e.GetTimerFired() != nil:
+		return KindTimer, e.GetTimerFired().GetTimerId(), true
+	case e.GetSubOrchestrationInstanceCompleted() != nil:
+		return KindChild, e.GetSubOrchestrationInstanceCompleted().GetTaskScheduledId(), true
+	case e.GetSubOrchestrationInstanceFailed() != nil:
+		return KindChild, e.GetSubOrchestrationInstanceFailed().GetTaskScheduledId(), true
+	}
+	return KindNone, 0, false
+}
+
+// IsPresent reports whether events contains a resolution event with the
+// given (kind, id) correlator.
+func IsPresent(events []*protos.HistoryEvent, kind Kind, id int32) bool {
+	for _, e := range events {
+		if k, existingID, ok := Of(e); ok && k == kind && existingID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/runtimestate/dedup/key.go
+++ b/backend/runtimestate/dedup/key.go
@@ -1,6 +1,6 @@
 // Package dedup detects duplicate task-resolution events
-// (TaskCompleted/TaskFailed/TimerFired/ChildWorkflowInstance{Completed,Failed})
-// inside a workflow's runtime state.
+// (TaskCompleted/TaskFailed/TimerFired/SubOrchestrationInstance{Completed,Failed})
+// inside an orchestration's runtime state.
 package dedup
 
 import "github.com/dapr/durabletask-go/api/protos"
@@ -16,8 +16,8 @@ const (
 	// the same id is still a duplicate.
 	KindTask
 	KindTimer
-	// KindChild covers ChildWorkflowInstanceCompleted and
-	// ChildWorkflowInstanceFailed, correlated by TaskScheduledId.
+	// KindChild covers SubOrchestrationInstanceCompleted and
+	// SubOrchestrationInstanceFailed, correlated by TaskScheduledId.
 	KindChild
 )
 

--- a/backend/runtimestate/dedup/set.go
+++ b/backend/runtimestate/dedup/set.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dedup
 
 import "github.com/dapr/durabletask-go/api/protos"

--- a/backend/runtimestate/dedup/set.go
+++ b/backend/runtimestate/dedup/set.go
@@ -1,0 +1,74 @@
+package dedup
+
+import "github.com/dapr/durabletask-go/api/protos"
+
+// setKey packs (kind, id) into a single comparable so Set's underlying map
+// uses a trivially-hashable key rather than a struct.
+type setKey int64
+
+func packKey(kind Kind, id int32) setKey {
+	return setKey(uint64(kind)<<32 | uint64(uint32(id)))
+}
+
+// Set is a constant-time duplicate detector for resolution-key events. The
+// nil Set is a sentinel: methods on it return false so callers can fall
+// back to a linear walk via IsPresent.
+type Set map[setKey]struct{}
+
+// New returns an empty Set sized for hint expected entries.
+func New(hint int) Set {
+	return make(Set, hint)
+}
+
+// NewForState returns a Set pre-populated with every resolution key in
+// s.OldEvents and s.NewEvents.
+func NewForState(s *protos.OrchestrationRuntimeState) Set {
+	rs := New(len(s.OldEvents) + len(s.NewEvents))
+	rs.populate(s.OldEvents)
+	rs.populate(s.NewEvents)
+	return rs
+}
+
+// Has reports whether (kind, id) is already in the set.
+func (s Set) Has(kind Kind, id int32) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s[packKey(kind, id)]
+	return ok
+}
+
+// Add records (kind, id). Returns true if the key was already present.
+func (s Set) Add(kind Kind, id int32) bool {
+	if s == nil {
+		return false
+	}
+	k := packKey(kind, id)
+	if _, dup := s[k]; dup {
+		return true
+	}
+	s[k] = struct{}{}
+	return false
+}
+
+// Observe extracts the resolution key from e and records it. Returns true
+// if the key was already present. Returns false for events without
+// resolution semantics or when called on a nil Set.
+func (s Set) Observe(e *protos.HistoryEvent) (duplicate bool) {
+	if s == nil {
+		return false
+	}
+	k, id, ok := Of(e)
+	if !ok {
+		return false
+	}
+	return s.Add(k, id)
+}
+
+func (s Set) populate(events []*protos.HistoryEvent) {
+	for _, e := range events {
+		if k, id, ok := Of(e); ok {
+			s[packKey(k, id)] = struct{}{}
+		}
+	}
+}

--- a/backend/runtimestate/dedup/set.go
+++ b/backend/runtimestate/dedup/set.go
@@ -51,20 +51,6 @@ func (s Set) Add(kind Kind, id int32) bool {
 	return false
 }
 
-// Observe extracts the resolution key from e and records it. Returns true
-// if the key was already present. Returns false for events without
-// resolution semantics or when called on a nil Set.
-func (s Set) Observe(e *protos.HistoryEvent) (duplicate bool) {
-	if s == nil {
-		return false
-	}
-	k, id, ok := Of(e)
-	if !ok {
-		return false
-	}
-	return s.Add(k, id)
-}
-
 func (s Set) populate(events []*protos.HistoryEvent) {
 	for _, e := range events {
 		if k, id, ok := Of(e); ok {

--- a/backend/runtimestate/runtimestate.go
+++ b/backend/runtimestate/runtimestate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/helpers"
 	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/runtimestate/dedup"
 )
 
 var ErrDuplicateEvent = errors.New("duplicate event")
@@ -23,19 +24,42 @@ func NewOrchestrationRuntimeState(instanceID string, customStatus *wrapperspb.St
 		CustomStatus: customStatus,
 	}
 
+	seen := dedup.New(len(existingHistory))
 	for _, e := range existingHistory {
-		addEvent(s, e, false)
+		addEventWithDedup(s, e, false, seen)
 	}
 
 	return s
 }
 
-// AddEvent appends a new history event to the orchestration history
+// AddEvent appends a new history event to the workflow history.
 func AddEvent(s *protos.OrchestrationRuntimeState, e *protos.HistoryEvent) error {
-	return addEvent(s, e, true)
+	return addEventWithDedup(s, e, true, nil)
+}
+
+// AddEvents appends a batch of new history events. errs is aligned with
+// events; nil entries indicate a successful add, non-nil entries (typically
+// ErrDuplicateEvent) indicate the event was rejected and not appended.
+func AddEvents(s *protos.OrchestrationRuntimeState, events []*protos.HistoryEvent) []error {
+	if len(events) == 0 {
+		return nil
+	}
+	seen := dedup.NewForState(s)
+	errs := make([]error, len(events))
+	for i, e := range events {
+		errs[i] = addEventWithDedup(s, e, true, seen)
+	}
+	return errs
 }
 
 func addEvent(s *protos.OrchestrationRuntimeState, e *protos.HistoryEvent, isNew bool) error {
+	return addEventWithDedup(s, e, isNew, nil)
+}
+
+// addEventWithDedup is the shared body of AddEvent / addEvent. When seen is
+// nil the resolution-key duplicate check scans OldEvents and NewEvents;
+// otherwise the set is consulted and updated.
+func addEventWithDedup(s *protos.OrchestrationRuntimeState, e *protos.HistoryEvent, isNew bool, seen dedup.Set) error {
 	if startEvent := e.GetExecutionStarted(); startEvent != nil {
 		if s.StartEvent != nil {
 			return ErrDuplicateEvent
@@ -57,8 +81,16 @@ func addEvent(s *protos.OrchestrationRuntimeState, e *protos.HistoryEvent, isNew
 			Reason:      stalledEvent.Reason,
 			Description: stalledEvent.Description,
 		}
-	} else {
-		// TODO: Check for other possible duplicates using task IDs
+	} else if kind, id, ok := dedup.Of(e); ok {
+		// Once a scheduled task or timer has resolved, any further
+		// resolution event for the same id is a duplicate.
+		if seen != nil {
+			if seen.Add(kind, id) {
+				return ErrDuplicateEvent
+			}
+		} else if dedup.IsPresent(s.OldEvents, kind, id) || dedup.IsPresent(s.NewEvents, kind, id) {
+			return ErrDuplicateEvent
+		}
 	}
 
 	// Any successfully processed event clears a prior stalled state, unless

--- a/backend/runtimestate/runtimestate.go
+++ b/backend/runtimestate/runtimestate.go
@@ -52,13 +52,10 @@ func AddEvents(s *protos.OrchestrationRuntimeState, events []*protos.HistoryEven
 	return errs
 }
 
-func addEvent(s *protos.OrchestrationRuntimeState, e *protos.HistoryEvent, isNew bool) error {
-	return addEventWithDedup(s, e, isNew, nil)
-}
-
-// addEventWithDedup is the shared body of AddEvent / addEvent. When seen is
-// nil the resolution-key duplicate check scans OldEvents and NewEvents;
-// otherwise the set is consulted and updated.
+// addEventWithDedup is the shared body behind AddEvent / AddEvents and the
+// bulk loader in NewOrchestrationRuntimeState. When seen is nil the
+// resolution-key duplicate check scans OldEvents and NewEvents; otherwise the
+// set is consulted and updated.
 func addEventWithDedup(s *protos.OrchestrationRuntimeState, e *protos.HistoryEvent, isNew bool, seen dedup.Set) error {
 	if startEvent := e.GetExecutionStarted(); startEvent != nil {
 		if s.StartEvent != nil {

--- a/backend/runtimestate/runtimestate_test.go
+++ b/backend/runtimestate/runtimestate_test.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/runtimestate/dedup"
 )
 
 func startedEvent() *protos.HistoryEvent {
@@ -182,4 +183,197 @@ func TestAddEvent_StalledReplacedByNewStalled(t *testing.T) {
 	require.NotNil(t, s.Stalled)
 	assert.Equal(t, protos.StalledReason_VERSION_NOT_AVAILABLE, s.Stalled.Reason)
 	assert.Equal(t, "second stall", s.Stalled.GetDescription())
+}
+
+func taskCompletedEvent(taskScheduledID int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: taskScheduledID,
+			},
+		},
+	}
+}
+
+func taskFailedEvent(taskScheduledID int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskFailed{
+			TaskFailed: &protos.TaskFailedEvent{
+				TaskScheduledId: taskScheduledID,
+			},
+		},
+	}
+}
+
+func timerFiredEvent(timerID int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TimerFired{
+			TimerFired: &protos.TimerFiredEvent{
+				TimerId: timerID,
+			},
+		},
+	}
+}
+
+func childWorkflowCompletedEvent(taskScheduledID int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_SubOrchestrationInstanceCompleted{
+			SubOrchestrationInstanceCompleted: &protos.SubOrchestrationInstanceCompletedEvent{
+				TaskScheduledId: taskScheduledID,
+			},
+		},
+	}
+}
+
+func childWorkflowFailedEvent(taskScheduledID int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_SubOrchestrationInstanceFailed{
+			SubOrchestrationInstanceFailed: &protos.SubOrchestrationInstanceFailedEvent{
+				TaskScheduledId: taskScheduledID,
+			},
+		},
+	}
+}
+
+func TestAddEvent_DuplicateTaskCompleted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		first     *protos.HistoryEvent
+		duplicate *protos.HistoryEvent
+	}{
+		{
+			name:      "TaskCompleted then TaskCompleted",
+			first:     taskCompletedEvent(1),
+			duplicate: taskCompletedEvent(1),
+		},
+		{
+			name:      "TaskCompleted then TaskFailed for same id",
+			first:     taskCompletedEvent(2),
+			duplicate: taskFailedEvent(2),
+		},
+		{
+			name:      "TaskFailed then TaskCompleted for same id",
+			first:     taskFailedEvent(3),
+			duplicate: taskCompletedEvent(3),
+		},
+		{
+			name:      "TimerFired then TimerFired",
+			first:     timerFiredEvent(7),
+			duplicate: timerFiredEvent(7),
+		},
+		{
+			name:      "SubOrchestrationInstanceCompleted then SubOrchestrationInstanceCompleted",
+			first:     childWorkflowCompletedEvent(4),
+			duplicate: childWorkflowCompletedEvent(4),
+		},
+		{
+			name:      "SubOrchestrationInstanceCompleted then SubOrchestrationInstanceFailed for same id",
+			first:     childWorkflowCompletedEvent(5),
+			duplicate: childWorkflowFailedEvent(5),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewOrchestrationRuntimeState("test-instance", nil, nil)
+			require.NoError(t, AddEvent(s, startedEvent()))
+			require.NoError(t, AddEvent(s, tt.first))
+
+			before := len(s.NewEvents)
+			err := AddEvent(s, tt.duplicate)
+			require.ErrorIs(t, err, ErrDuplicateEvent)
+			assert.Len(t, s.NewEvents, before, "duplicate event must not be appended")
+		})
+	}
+}
+
+func TestAddEvent_DistinctIDsAndKindsAreNotDuplicates(t *testing.T) {
+	t.Parallel()
+
+	s := NewOrchestrationRuntimeState("test-instance", nil, nil)
+	require.NoError(t, AddEvent(s, startedEvent()))
+
+	// Different task ids must each be accepted.
+	require.NoError(t, AddEvent(s, taskCompletedEvent(1)))
+	require.NoError(t, AddEvent(s, taskCompletedEvent(2)))
+
+	// Same id under a different kind is not a duplicate: the "task" and
+	// "timer" namespaces are independent.
+	require.NoError(t, AddEvent(s, timerFiredEvent(1)))
+	require.NoError(t, AddEvent(s, timerFiredEvent(2)))
+
+	// Same id under the "child" kind likewise distinct from "task".
+	require.NoError(t, AddEvent(s, childWorkflowCompletedEvent(1)))
+	require.NoError(t, AddEvent(s, childWorkflowCompletedEvent(2)))
+
+	assert.Len(t, s.NewEvents, 7, "started + 2 task + 2 timer + 2 child = 7 events")
+}
+
+func TestAddEvent_DuplicateAgainstOldEvents(t *testing.T) {
+	t.Parallel()
+
+	// Existing history (OldEvents) already contains a TaskCompleted for id=1.
+	s := NewOrchestrationRuntimeState("test-instance", nil, []*protos.HistoryEvent{
+		startedEvent(),
+		taskCompletedEvent(1),
+	})
+
+	// Redelivery of TaskCompleted#1 as a NewEvent must be detected.
+	err := AddEvent(s, taskCompletedEvent(1))
+	require.ErrorIs(t, err, ErrDuplicateEvent)
+	assert.Len(t, s.NewEvents, 0, "duplicate event must not be appended to NewEvents")
+	assert.Len(t, s.OldEvents, 2, "OldEvents unchanged")
+}
+
+func TestAddEvent_StalledPreservedOnDuplicateCompletion(t *testing.T) {
+	t.Parallel()
+
+	s := NewOrchestrationRuntimeState("test-instance", nil, nil)
+	require.NoError(t, AddEvent(s, startedEvent()))
+	require.NoError(t, AddEvent(s, taskCompletedEvent(1)))
+	require.NoError(t, AddEvent(s, stalledEvent(protos.StalledReason_PATCH_MISMATCH, "stalled")))
+	require.NotNil(t, s.Stalled)
+
+	// A duplicate completion must NOT clear the stalled state, mirroring
+	// the behaviour for duplicate ExecutionStarted.
+	err := AddEvent(s, taskCompletedEvent(1))
+	require.ErrorIs(t, err, ErrDuplicateEvent)
+	assert.NotNil(t, s.Stalled, "Stalled must be preserved across a duplicate-completion error")
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_STALLED, RuntimeStatus(s))
+}
+
+func TestAddEvent_NewOrchestrationRuntimeStateDropsHistoryDuplicates(t *testing.T) {
+	t.Parallel()
+
+	// If existing history somehow contains duplicates (e.g. written by a
+	// previous version that didn't dedup), NewOrchestrationRuntimeState must not
+	// surface them: it ignores AddEvent errors and the duplicate is simply
+	// not re-added to OldEvents. Without this property, upgrading would
+	// regress workflows that already accumulated duplicate history.
+	history := []*protos.HistoryEvent{
+		startedEvent(),
+		taskCompletedEvent(1),
+		taskCompletedEvent(1), // duplicate that NewOrchestrationRuntimeState should silently drop
+		taskCompletedEvent(2),
+	}
+	s := NewOrchestrationRuntimeState("test-instance", nil, history)
+
+	assert.Len(t, s.OldEvents, 3, "duplicate must not be re-added to OldEvents")
+	assert.True(t, dedup.IsPresent(s.OldEvents, dedup.KindTask, 1))
+	assert.True(t, dedup.IsPresent(s.OldEvents, dedup.KindTask, 2))
 }

--- a/backend/runtimestate/runtimestate_test.go
+++ b/backend/runtimestate/runtimestate_test.go
@@ -221,7 +221,7 @@ func timerFiredEvent(timerID int32) *protos.HistoryEvent {
 	}
 }
 
-func childWorkflowCompletedEvent(taskScheduledID int32) *protos.HistoryEvent {
+func subOrchestrationCompletedEvent(taskScheduledID int32) *protos.HistoryEvent {
 	return &protos.HistoryEvent{
 		EventId:   -1,
 		Timestamp: timestamppb.Now(),
@@ -233,7 +233,7 @@ func childWorkflowCompletedEvent(taskScheduledID int32) *protos.HistoryEvent {
 	}
 }
 
-func childWorkflowFailedEvent(taskScheduledID int32) *protos.HistoryEvent {
+func subOrchestrationFailedEvent(taskScheduledID int32) *protos.HistoryEvent {
 	return &protos.HistoryEvent{
 		EventId:   -1,
 		Timestamp: timestamppb.Now(),
@@ -275,13 +275,13 @@ func TestAddEvent_DuplicateTaskCompleted(t *testing.T) {
 		},
 		{
 			name:      "SubOrchestrationInstanceCompleted then SubOrchestrationInstanceCompleted",
-			first:     childWorkflowCompletedEvent(4),
-			duplicate: childWorkflowCompletedEvent(4),
+			first:     subOrchestrationCompletedEvent(4),
+			duplicate: subOrchestrationCompletedEvent(4),
 		},
 		{
 			name:      "SubOrchestrationInstanceCompleted then SubOrchestrationInstanceFailed for same id",
-			first:     childWorkflowCompletedEvent(5),
-			duplicate: childWorkflowFailedEvent(5),
+			first:     subOrchestrationCompletedEvent(5),
+			duplicate: subOrchestrationFailedEvent(5),
 		},
 	}
 
@@ -318,8 +318,8 @@ func TestAddEvent_DistinctIDsAndKindsAreNotDuplicates(t *testing.T) {
 	require.NoError(t, AddEvent(s, timerFiredEvent(2)))
 
 	// Same id under the "child" kind likewise distinct from "task".
-	require.NoError(t, AddEvent(s, childWorkflowCompletedEvent(1)))
-	require.NoError(t, AddEvent(s, childWorkflowCompletedEvent(2)))
+	require.NoError(t, AddEvent(s, subOrchestrationCompletedEvent(1)))
+	require.NoError(t, AddEvent(s, subOrchestrationCompletedEvent(2)))
 
 	assert.Len(t, s.NewEvents, 7, "started + 2 task + 2 timer + 2 child = 7 events")
 }

--- a/backend/runtimestate/runtimestate_test.go
+++ b/backend/runtimestate/runtimestate_test.go
@@ -327,17 +327,54 @@ func TestAddEvent_DistinctIDsAndKindsAreNotDuplicates(t *testing.T) {
 func TestAddEvent_DuplicateAgainstOldEvents(t *testing.T) {
 	t.Parallel()
 
-	// Existing history (OldEvents) already contains a TaskCompleted for id=1.
-	s := NewOrchestrationRuntimeState("test-instance", nil, []*protos.HistoryEvent{
-		startedEvent(),
-		taskCompletedEvent(1),
-	})
+	tests := []struct {
+		name      string
+		committed *protos.HistoryEvent
+		duplicate *protos.HistoryEvent
+	}{
+		{
+			name:      "TaskCompleted committed, TaskCompleted redelivered",
+			committed: taskCompletedEvent(1),
+			duplicate: taskCompletedEvent(1),
+		},
+		{
+			name:      "TaskCompleted committed, TaskFailed redelivered for same id",
+			committed: taskCompletedEvent(1),
+			duplicate: taskFailedEvent(1),
+		},
+		{
+			name:      "TaskFailed committed, TaskCompleted redelivered for same id",
+			committed: taskFailedEvent(1),
+			duplicate: taskCompletedEvent(1),
+		},
+		{
+			name:      "TimerFired committed, TimerFired redelivered",
+			committed: timerFiredEvent(2),
+			duplicate: timerFiredEvent(2),
+		},
+		{
+			name:      "SubOrchestrationInstanceCompleted committed, SubOrchestrationInstanceFailed redelivered for same id",
+			committed: subOrchestrationCompletedEvent(3),
+			duplicate: subOrchestrationFailedEvent(3),
+		},
+	}
 
-	// Redelivery of TaskCompleted#1 as a NewEvent must be detected.
-	err := AddEvent(s, taskCompletedEvent(1))
-	require.ErrorIs(t, err, ErrDuplicateEvent)
-	assert.Len(t, s.NewEvents, 0, "duplicate event must not be appended to NewEvents")
-	assert.Len(t, s.OldEvents, 2, "OldEvents unchanged")
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewOrchestrationRuntimeState("test-instance", nil, []*protos.HistoryEvent{
+				startedEvent(),
+				tt.committed,
+			})
+
+			err := AddEvent(s, tt.duplicate)
+			require.ErrorIs(t, err, ErrDuplicateEvent)
+			assert.Empty(t, s.NewEvents, "duplicate event must not be appended to NewEvents")
+			assert.Len(t, s.OldEvents, 2, "OldEvents unchanged")
+		})
+	}
 }
 
 func TestAddEvent_StalledPreservedOnDuplicateCompletion(t *testing.T) {


### PR DESCRIPTION
TaskCompleted, TaskFailed, TimerFired and ChildWorkflowInstance {Completed,Failed} were treated as untracked events by addEvent: a duplicate delivery of any of them was appended to the runtime state unchanged, leaving the orchestrator to discover the inconsistency on replay. When the dapr workflow actor's inbox redelivers a completion (e.g. an activity actor reminder firing twice during pod migration), this drove the language SDK into the "Ignoring unexpected ..." silent return and a reminder/run spin loop.

addEvent now rejects a resolution event whose (kind, id) correlator is already present in either OldEvents or NewEvents, returning ErrDuplicateEvent the same way ExecutionStarted/ExecutionCompleted already do. The Stalled-clear path runs only on a successful add, so duplicates do not silently clear a prior stall.