### PR TITLE
Bind chunk identity into propagation signature input

### DIFF
--- a/backend/historysigning/canonical.go
+++ b/backend/historysigning/canonical.go
@@ -56,11 +56,31 @@ func SignatureDigest(rawSig []byte) []byte {
 	return d[:]
 }
 
-// SignatureInput computes the input to the cryptographic signing operation:
-// SHA-256(previousSignatureDigest || eventsDigest).
-func SignatureInput(previousSignatureDigest, eventsDigest []byte) []byte {
+// PropagationContext binds a propagated-history chunk's instance and
+// workflow name into the signature input so a legitimately signed chunk
+// can't be lifted from state and replayed under a different instanceId
+// or workflowName.
+type PropagationContext struct {
+	InstanceID   string
+	WorkflowName string
+}
+
+// SignatureInput computes the input to the cryptographic signing
+// operation: SHA-256(previousSignatureDigest || eventsDigest || ctxBytes),
+// where ctxBytes is the length-prefixed serialization of ctx's fields
+// when ctx is non-nil. Own-history signing passes nil; propagation
+// signing passes a fully populated *PropagationContext.
+func SignatureInput(previousSignatureDigest, eventsDigest []byte, ctx *PropagationContext) []byte {
 	h := sha256.New()
 	h.Write(previousSignatureDigest)
 	h.Write(eventsDigest)
+	if ctx != nil {
+		var lenBuf [8]byte
+		for _, s := range []string{ctx.InstanceID, ctx.WorkflowName} {
+			binary.BigEndian.PutUint64(lenBuf[:], uint64(len(s)))
+			h.Write(lenBuf[:])
+			h.Write([]byte(s))
+		}
+	}
 	return h.Sum(nil)
 }

--- a/backend/historysigning/historysigning_test.go
+++ b/backend/historysigning/historysigning_test.go
@@ -212,7 +212,7 @@ func TestSignAndVerifyEd25519(t *testing.T) {
 
 	// Verify
 	certs := []*protos.SigningCertificate{result.NewCert}
-	err = VerifySignature(tc, result.Signature, certs, raw)
+	err = VerifySignature(tc, result.Signature, certs, raw, nil)
 	require.NoError(t, err)
 }
 
@@ -231,7 +231,7 @@ func TestSignAndVerifyECDSA(t *testing.T) {
 	require.NoError(t, err)
 
 	certs := []*protos.SigningCertificate{result.NewCert}
-	err = VerifySignature(tc, result.Signature, certs, raw)
+	err = VerifySignature(tc, result.Signature, certs, raw, nil)
 	require.NoError(t, err)
 }
 
@@ -250,7 +250,7 @@ func TestSignAndVerifyRSA(t *testing.T) {
 	require.NoError(t, err)
 
 	certs := []*protos.SigningCertificate{result.NewCert}
-	err = VerifySignature(tc, result.Signature, certs, raw)
+	err = VerifySignature(tc, result.Signature, certs, raw, nil)
 	require.NoError(t, err)
 }
 
@@ -351,7 +351,7 @@ func TestTamperedHistoryDetection(t *testing.T) {
 	raw[1], err = MarshalEvent(events[1])
 	require.NoError(t, err)
 
-	err = VerifySignature(tc, result.Signature, certs, raw)
+	err = VerifySignature(tc, result.Signature, certs, raw, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "events digest mismatch")
 }
@@ -413,7 +413,7 @@ func TestWrongCertificateIndex(t *testing.T) {
 	// The signature was produced with cert1's key, but we tell the verifier
 	// that the cert at index 0 is cert2.
 	wrongCerts := []*protos.SigningCertificate{{Certificate: certDER2}}
-	err = VerifySignature(tc, result.Signature, wrongCerts, raw)
+	err = VerifySignature(tc, result.Signature, wrongCerts, raw, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signature verification failed")
 }
@@ -456,7 +456,7 @@ func TestCertificateExpiredAtEventTime(t *testing.T) {
 	require.NoError(t, err)
 
 	certs := []*protos.SigningCertificate{result.NewCert}
-	err = VerifySignature(tc, result.Signature, certs, raw)
+	err = VerifySignature(tc, result.Signature, certs, raw, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "certificate not valid at event time")
 }
@@ -480,7 +480,7 @@ func TestCertificateNotYetValidAtEventTime(t *testing.T) {
 	require.NoError(t, err)
 
 	certs := []*protos.SigningCertificate{result.NewCert}
-	err = VerifySignature(tc, result.Signature, certs, raw)
+	err = VerifySignature(tc, result.Signature, certs, raw, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "certificate not valid at event time")
 }
@@ -504,7 +504,7 @@ func TestCertificateValidAtEventTime(t *testing.T) {
 	require.NoError(t, err)
 
 	certs := []*protos.SigningCertificate{result.NewCert}
-	err = VerifySignature(tc, result.Signature, certs, raw)
+	err = VerifySignature(tc, result.Signature, certs, raw, nil)
 	require.NoError(t, err)
 }
 
@@ -597,7 +597,7 @@ func TestRawBytesRoundTrip(t *testing.T) {
 	}
 
 	certs := []*protos.SigningCertificate{result.NewCert}
-	err = VerifySignature(tc, result.Signature, certs, roundTripped)
+	err = VerifySignature(tc, result.Signature, certs, roundTripped, nil)
 	require.NoError(t, err)
 }
 
@@ -674,7 +674,7 @@ func TestSignAndVerifyWithCertChain(t *testing.T) {
 
 	// Verification should succeed — parseCertificateChainDER extracts the leaf.
 	certs := []*protos.SigningCertificate{result.NewCert}
-	err = VerifySignature(tc, result.Signature, certs, raw)
+	err = VerifySignature(tc, result.Signature, certs, raw, nil)
 	require.NoError(t, err)
 }
 
@@ -826,7 +826,7 @@ func TestSignWithIntermediateCertChain(t *testing.T) {
 
 	// Verify — the leaf's public key should be used for verification.
 	certs := []*protos.SigningCertificate{result.NewCert}
-	err = VerifySignature(tc, result.Signature, certs, raw)
+	err = VerifySignature(tc, result.Signature, certs, raw, nil)
 	require.NoError(t, err)
 }
 

--- a/backend/historysigning/propagation.go
+++ b/backend/historysigning/propagation.go
@@ -164,11 +164,19 @@ func VerifyPropagatedHistory(opts VerifyPropagationOptions) (*PropagationVerifyR
 		// not produce the same deterministic output as the producer's,
 		// and the whole point of carrying rawEvents per chunk is to
 		// make verification independent of marshaler stability.
+		//
+		// Bind the chunk's instance and workflow name into the signature
+		// input so a chunk can't be lifted from one instance and
+		// relabeled as another.
 		referenced, err := VerifyChain(VerifyChainOptions{
 			RawSignatures: chunk.GetRawSignatures(),
 			Certs:         certs,
 			AllRawEvents:  chunk.GetRawEvents(),
 			Signer:        opts.Signer,
+			PropagationContext: &PropagationContext{
+				InstanceID:   chunk.GetInstanceId(),
+				WorkflowName: chunk.GetWorkflowName(),
+			},
 		})
 		if err != nil {
 			return nil, fmt.Errorf("chunk %d (app %q): %w", i, chunk.GetAppId(), err)

--- a/backend/historysigning/propagation_test.go
+++ b/backend/historysigning/propagation_test.go
@@ -29,15 +29,30 @@ import (
 	"github.com/dapr/kit/crypto/spiffe/signer"
 )
 
-// signChunk marshals events, signs them, and returns the (rawEvents, rawSigs,
-// certChains) triple a producer would attach to a PropagatedHistoryChunk.
+// signChunk marshals events, signs them with the chunk's identity binding,
+// and returns the (rawEvents, rawSigs, certChains) triple a producer would
+// attach to a PropagatedHistoryChunk built by makePropagatedHistory. The
+// binding matches the instanceId / workflowName used in
+// makePropagatedHistory so the resulting chunk verifies cleanly.
 func signChunk(t *testing.T, s *signer.Signer, events []*protos.HistoryEvent) (rawEvents, rawSigs, certs [][]byte) {
+	return signChunkWithBinding(t, s, events, "wf-1", "TestWorkflow")
+}
+
+// signChunkWithBinding is signChunk's variant that lets the caller pin the
+// chunk identity used for the context binding - needed for tests that
+// build chunks under a different instanceId or workflowName than the
+// helper's defaults (e.g. the two-chunk lineage test).
+func signChunkWithBinding(t *testing.T, s *signer.Signer, events []*protos.HistoryEvent, instanceID, workflowName string) (rawEvents, rawSigs, certs [][]byte) {
 	t.Helper()
 	rawEvents = marshalEvents(t, events)
 	res, err := Sign(s, SignOptions{
 		RawEvents:       rawEvents,
 		StartEventIndex: 0,
 		ExistingCerts:   nil,
+		PropagationContext: &PropagationContext{
+			InstanceID:   instanceID,
+			WorkflowName: workflowName,
+		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, res.NewCert)
@@ -163,8 +178,8 @@ func TestVerifyPropagatedHistory_TwoChunksLineage(t *testing.T) {
 	events := testEvents()
 	require.GreaterOrEqual(t, len(events), 3)
 
-	rawA, rawSigsA, certsA := signChunk(t, signerA, events[:2])
-	rawB, rawSigsB, certsB := signChunk(t, signerB, events[2:])
+	rawA, rawSigsA, certsA := signChunkWithBinding(t, signerA, events[:2], "wf-a", "A")
+	rawB, rawSigsB, certsB := signChunkWithBinding(t, signerB, events[2:], "wf-b", "B")
 
 	ph := &protos.PropagatedHistory{
 		Scope: protos.HistoryPropagationScope_HISTORY_PROPAGATION_SCOPE_LINEAGE,
@@ -205,6 +220,33 @@ func TestVerifyPropagatedHistory_EmptyChunkWithSigs(t *testing.T) {
 	_, err := VerifyPropagatedHistory(VerifyPropagationOptions{History: ph, Signer: s, ExpectedNamespace: "default"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty rawEvents")
+}
+
+// TestVerifyPropagatedHistory_RelabeledChunkRejected verifies that the
+// chunk's identity (appId/instanceId/workflowName) is bound into the
+// signature input. A chunk legitimately signed for one instance cannot be
+// lifted and relabeled to a different instance under the same app and
+// still verify.
+func TestVerifyPropagatedHistory_RelabeledChunkRejected(t *testing.T) {
+	certDER, priv := generateEd25519Cert(t) // /ns/default/app-a
+	events := testEvents()
+	s := newTestSigner(t, certDER, priv, parseCert(t, certDER))
+
+	// Sign for the legitimate (app-a, wf-1, TestWorkflow) identity.
+	rawEvents, rawSigs, certs := signChunk(t, s, events)
+	ph := makePropagatedHistory("app-a", "wf-1", rawEvents, rawSigs, certs)
+
+	// Tamper: relabel the chunk's instanceId to something else. Cert
+	// SPIFFE check still passes (app component is app-a) but the
+	// signature input no longer matches because the binding shifted.
+	ph.GetChunks()[0].InstanceId = "wf-relabeled"
+
+	_, err := VerifyPropagatedHistory(VerifyPropagationOptions{
+		History:           ph,
+		Signer:            s,
+		ExpectedNamespace: "default",
+	})
+	require.Error(t, err)
 }
 
 // TestVerifyPropagatedHistory_EmptyChunkRejected verifies that any chunk

--- a/backend/historysigning/propagation_test.go
+++ b/backend/historysigning/propagation_test.go
@@ -223,22 +223,23 @@ func TestVerifyPropagatedHistory_EmptyChunkWithSigs(t *testing.T) {
 }
 
 // TestVerifyPropagatedHistory_RelabeledChunkRejected verifies that the
-// chunk's identity (appId/instanceId/workflowName) is bound into the
-// signature input. A chunk legitimately signed for one instance cannot be
-// lifted and relabeled to a different instance under the same app and
-// still verify.
+// chunk's instance and workflow name are bound into the signature input.
+// A chunk legitimately signed for one (instance, workflow) cannot be
+// lifted and relabeled to a different one under the same app and still
+// verify. AppID is not in the binding because VerifyCertAppIdentity
+// pins it to the cert's SPIFFE app component.
 func TestVerifyPropagatedHistory_RelabeledChunkRejected(t *testing.T) {
 	certDER, priv := generateEd25519Cert(t) // /ns/default/app-a
 	events := testEvents()
 	s := newTestSigner(t, certDER, priv, parseCert(t, certDER))
 
-	// Sign for the legitimate (app-a, wf-1, TestWorkflow) identity.
+	// Sign for the legitimate (wf-1, TestWorkflow) identity.
 	rawEvents, rawSigs, certs := signChunk(t, s, events)
 	ph := makePropagatedHistory("app-a", "wf-1", rawEvents, rawSigs, certs)
 
-	// Tamper: relabel the chunk's instanceId to something else. Cert
-	// SPIFFE check still passes (app component is app-a) but the
-	// signature input no longer matches because the binding shifted.
+	// Tamper: relabel the chunk's instanceId. Cert SPIFFE check still
+	// passes (app component is app-a, namespace is default) but the
+	// signature input shifts, so the cryptographic verification fails.
 	ph.GetChunks()[0].InstanceId = "wf-relabeled"
 
 	_, err := VerifyPropagatedHistory(VerifyPropagationOptions{
@@ -247,6 +248,9 @@ func TestVerifyPropagatedHistory_RelabeledChunkRejected(t *testing.T) {
 		ExpectedNamespace: "default",
 	})
 	require.Error(t, err)
+	// Pin the failure to the signature path so a future unrelated
+	// validation change can't quietly swallow this assertion.
+	assert.Contains(t, err.Error(), "signature verification failed")
 }
 
 // TestVerifyPropagatedHistory_EmptyChunkRejected verifies that any chunk

--- a/backend/historysigning/signer.go
+++ b/backend/historysigning/signer.go
@@ -55,6 +55,13 @@ type SignOptions struct {
 	PreviousSignatureRaw []byte
 	// ExistingCerts is the current certificate table.
 	ExistingCerts []*protos.SigningCertificate
+	// PropagationContext is the optional binding fed into SignatureInput
+	// so metadata that lives outside RawEvents (the chunk's declared
+	// identity) is part of what was signed. Nil for own-history
+	// signatures, populated for propagated-history chunks. Verifiers
+	// must reconstruct an equivalent context and supply it via
+	// VerifyChainOptions.PropagationContext.
+	PropagationContext *PropagationContext
 }
 
 // Sign creates a HistorySignature covering a range of events. The RawEvents
@@ -79,7 +86,7 @@ func Sign(s *signer.Signer, opts SignOptions) (*SignResult, error) {
 	}
 
 	// Compute the signature input
-	sigInput := SignatureInput(prevSigDigest, eventsDigest)
+	sigInput := SignatureInput(prevSigDigest, eventsDigest, opts.PropagationContext)
 
 	// Sign
 	sigBytes, certChainDER, err := s.Sign(sigInput)

--- a/backend/historysigning/verify.go
+++ b/backend/historysigning/verify.go
@@ -32,15 +32,18 @@ import (
 // raw bytes as stored in the state store for every history event, in order.
 // Never re-marshal events from Go structs for verification, as protobuf
 // deterministic marshaling is not stable across binary versions.
-func VerifySignature(s *signer.Signer, sig *protos.HistorySignature, certs []*protos.SigningCertificate, allRawEvents [][]byte) error {
-	_, err := verifySignature(s, sig, certs, allRawEvents)
+//
+// Pass nil for ctx when verifying own-history signatures. Propagation
+// chunks must pass the same *PropagationContext the signer used.
+func VerifySignature(s *signer.Signer, sig *protos.HistorySignature, certs []*protos.SigningCertificate, allRawEvents [][]byte, ctx *PropagationContext) error {
+	_, err := verifySignature(s, sig, certs, allRawEvents, ctx)
 	return err
 }
 
 // verifySignature is the internal implementation that also returns the event
 // time of the last event in the signed range, for use in chain-of-trust
 // verification.
-func verifySignature(s *signer.Signer, sig *protos.HistorySignature, certs []*protos.SigningCertificate, allRawEvents [][]byte) (time.Time, error) {
+func verifySignature(s *signer.Signer, sig *protos.HistorySignature, certs []*protos.SigningCertificate, allRawEvents [][]byte, ctx *PropagationContext) (time.Time, error) {
 	var zero time.Time
 
 	if s == nil {
@@ -107,7 +110,7 @@ func verifySignature(s *signer.Signer, sig *protos.HistorySignature, certs []*pr
 	}
 
 	// Verify the cryptographic signature
-	sigInput := SignatureInput(sig.GetPreviousSignatureDigest(), sig.GetEventsDigest())
+	sigInput := SignatureInput(sig.GetPreviousSignatureDigest(), sig.GetEventsDigest(), ctx)
 
 	if err := s.VerifySignature(sigInput, sig.GetSignature(), certDER); err != nil {
 		return zero, fmt.Errorf("signature verification failed: %w", err)
@@ -120,7 +123,7 @@ func verifySignature(s *signer.Signer, sig *protos.HistorySignature, certs []*pr
 type VerifyChainOptions struct {
 	// RawSignatures is the raw serialized bytes of each HistorySignature,
 	// as stored in the state store or from SignResult.RawSignature. These
-	// are the single source of truth — they are both parsed into
+	// are the single source of truth - they are both parsed into
 	// HistorySignature structs and used for digest computation in chain
 	// linking.
 	RawSignatures [][]byte
@@ -131,6 +134,10 @@ type VerifyChainOptions struct {
 	// Signer provides cryptographic verification and certificate chain-of-trust
 	// checking.
 	Signer *signer.Signer
+	// PropagationContext is the optional binding fed into SignatureInput
+	// at sign time (see SignOptions.PropagationContext). Nil for
+	// own-history chains, non-nil for propagation chunks.
+	PropagationContext *PropagationContext
 }
 
 // VerifyChain walks the full signature chain and verifies each signature,
@@ -194,7 +201,7 @@ func VerifyChain(opts VerifyChainOptions) (map[uint64]struct{}, error) {
 			return nil, fmt.Errorf("signature %d: expected start event index %d, got %d", i, expectedStart, sig.GetStartEventIndex())
 		}
 
-		eventTime, err := verifySignature(opts.Signer, sig, opts.Certs, opts.AllRawEvents)
+		eventTime, err := verifySignature(opts.Signer, sig, opts.Certs, opts.AllRawEvents, opts.PropagationContext)
 		if err != nil {
 			return nil, fmt.Errorf("signature %d: %w", i, err)
 		}


### PR DESCRIPTION
Without identity binding, a chunk legitimately signed under (instance-X, workflow-Y) could be lifted from the persisted state and relabeled under another (instance, workflow) by an attacker with state-store access - the cert SPIFFE check still passes for the same app, and the signature otherwise verifies because RawEvents and RawSignatures stay byte-identical.

Add a PropagationContext{InstanceID, WorkflowName} that gets length-prefixed and folded into SignatureInput at sign and verify time. Producers populate it from the chunk they're signing; receivers reconstruct it from the chunk's claimed values. Own-history signing passes nil and behaves identically to before.