### PR TITLE
fix: use protojson camelcase default for wf payload serialization

### DIFF
--- a/api/orchestration.go
+++ b/api/orchestration.go
@@ -198,8 +198,9 @@ func WithRerunInput(input any) RerunOptions {
 	}
 }
 
-// protoMarshaler uses UseProtoNames so JSON output uses snake_case field names.
-var protoMarshaler = protojson.MarshalOptions{UseProtoNames: true}
+// protoMarshaler uses default protojson options so JSON output uses camelCase
+// field names (the protojson default).
+var protoMarshaler = protojson.MarshalOptions{}
 
 // marshalData serializes v to JSON. Proto message types use protojson for
 // correct handling of well-known types (e.g. google.protobuf.Struct);

--- a/task/executor.go
+++ b/task/executor.go
@@ -187,9 +187,9 @@ func (te taskExecutor) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// protoMarshaler uses UseProtoNames so JSON output uses snake_case field names
-// (matching the proto field names), which is the convention for workflow payloads.
-var protoMarshaler = protojson.MarshalOptions{UseProtoNames: true}
+// protoMarshaler uses default protojson options so JSON output uses camelCase
+// field names (the protojson default).
+var protoMarshaler = protojson.MarshalOptions{}
 
 func unmarshalData(data []byte, v any) error {
 	if v == nil {


### PR DESCRIPTION
## Summary
- Proto-typed workflow payloads (e.g. `google.protobuf.Struct`) now serialize to camelCase JSON — the protojson default and standard JSON wire convention
- Pure-Go payloads were already camelCase via `json` tags; this fixes mixed-case output when both flow through the same `marshalData` helper

## Why
Workflow outputs were producing mixed camelCase/snake_case JSON depending on whether the field originated from a proto type or a Go struct. External consumers (MCP spec, JSON SDKs in other languages) expect camelCase consistently. Defaulting protojson to camelCase aligns proto payloads with that convention.