### PR TITLE
[0.12] recursive terminate emits child terminations as pending messages

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -259,30 +259,31 @@ type childWorkflowRef struct {
 	Router     *protos.TaskRouter
 }
 
-// terminateChildWorkflowInstances submits termination requests to child workflows if [et.Recurse] is true.
-func terminateChildWorkflowInstances(ctx context.Context, be Backend, iid api.InstanceID, state *WorkflowRuntimeState, et *protos.ExecutionTerminatedEvent) error {
+// appendCascadeTerminateMessages appends one ExecutionTerminated pending
+// message per child workflow to the runtime state if [et.Recurse] is true.
+// The backend delivers these when completing the work item, so a failed
+// child delivery cannot abort the parent's own completion and strand it in
+// RUNNING.
+func appendCascadeTerminateMessages(state *WorkflowRuntimeState, et *protos.ExecutionTerminatedEvent) {
 	if !et.Recurse {
-		return nil
+		return
 	}
-	childWorkflowInstances := getChildWorkflowInstances(state.OldEvents, state.NewEvents)
-	for _, child := range childWorkflowInstances {
-		e := &protos.HistoryEvent{
-			EventId:   -1,
-			Timestamp: timestamppb.Now(),
-			EventType: &protos.HistoryEvent_ExecutionTerminated{
-				ExecutionTerminated: &protos.ExecutionTerminatedEvent{
-					Input:   et.Input,
-					Recurse: et.Recurse,
+	for _, child := range getChildWorkflowInstances(state.OldEvents, state.NewEvents) {
+		state.PendingMessages = append(state.PendingMessages, &protos.WorkflowRuntimeStateMessage{
+			TargetInstanceId: string(child.InstanceID),
+			HistoryEvent: &protos.HistoryEvent{
+				EventId:   -1,
+				Timestamp: timestamppb.Now(),
+				EventType: &protos.HistoryEvent_ExecutionTerminated{
+					ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+						Input:   et.Input,
+						Recurse: et.Recurse,
+					},
 				},
+				Router: child.Router,
 			},
-			Router: child.Router,
-		}
-		// Adding terminate event to child workflow instance
-		if err := be.AddNewWorkflowEvent(ctx, child.InstanceID, e); err != nil {
-			return fmt.Errorf("failed to submit termination request to child workflow: %w", err)
-		}
+		})
 	}
-	return nil
 }
 
 // getChildWorkflowInstances returns each child workflow recorded in the given

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
@@ -374,4 +375,39 @@ func TestPurgeWorkflowState_Recursive_ForceBypassesIsCompleted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 	assert.Equal(t, []api.InstanceID{childID, parentID}, be.purgeCalls)
+}
+
+func TestAppendCascadeTerminateMessages_EmitsPendingMessagePerChild(t *testing.T) {
+	state := &WorkflowRuntimeState{
+		OldEvents: []*HistoryEvent{childCreatedEvent("child-old", nil)},
+		NewEvents: []*HistoryEvent{childCreatedEvent("child-new", ptr.Of("other-ns"))},
+	}
+
+	appendCascadeTerminateMessages(state, &protos.ExecutionTerminatedEvent{
+		Input:   wrapperspb.String("reason"),
+		Recurse: true,
+	})
+
+	require.Len(t, state.PendingMessages, 2)
+	byTarget := make(map[string]*protos.WorkflowRuntimeStateMessage, 2)
+	for _, msg := range state.PendingMessages {
+		byTarget[msg.GetTargetInstanceId()] = msg
+	}
+	for _, target := range []string{"child-old", "child-new"} {
+		msg, ok := byTarget[target]
+		require.True(t, ok, "missing pending message for %s", target)
+		et := msg.GetHistoryEvent().GetExecutionTerminated()
+		require.NotNil(t, et)
+		assert.True(t, et.GetRecurse())
+		assert.Equal(t, "reason", et.GetInput().GetValue())
+	}
+	assert.Equal(t, "other-ns", byTarget["child-new"].GetHistoryEvent().GetRouter().GetTargetAppNamespace())
+}
+
+func TestAppendCascadeTerminateMessages_NonRecursiveIsNoOp(t *testing.T) {
+	state := &WorkflowRuntimeState{
+		OldEvents: []*HistoryEvent{childCreatedEvent("child", nil)},
+	}
+	appendCascadeTerminateMessages(state, &protos.ExecutionTerminatedEvent{Recurse: false})
+	assert.Empty(t, state.PendingMessages)
 }

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -185,9 +185,7 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 		}
 	}
 	if terminateEvent != nil && runtimestate.IsCompleted(wi.State) {
-		if err := terminateChildWorkflowInstances(ctx, w.be, wi.InstanceID, wi.State, terminateEvent); err != nil {
-			return err
-		}
+		appendCascadeTerminateMessages(wi.State, terminateEvent)
 	}
 	return nil
 }


### PR DESCRIPTION
ProcessWorkItem previously delivered the recursive ExecutionTerminated to each child inline via AddNewWorkflowEvent, before the parent's own completion was committed. A single failed child send (unreachable host, reminder creation failure) aborted the work item and rolled back the parent's not-yet-committed terminal state, leaving the parent stuck RUNNING with the termination event undrained in its inbox. Every reactivation then repeated the same failing fan-out, so the workflow could never be terminated, only purged.

The cascade is now appended to the runtime state as one ExecutionTerminated pending message per child, preserving each child's router for cross-app dispatch. Delivery becomes the backend's responsibility when completing the work item: the sqlite and postgres backends persist the messages intothe same
transaction as the parent's terminal state, and the dapr actors backend delivers them after the parent's cing from
durable history.