### PR TITLE
Add support for large payloads store

### DIFF
--- a/backend/activity.go
+++ b/backend/activity.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/helpers"
 	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/payloadstore"
 )
 
 type activityProcessor struct {
@@ -18,33 +19,38 @@ type activityProcessor struct {
 	executor            ActivityExecutor
 	inProcessExecutor   ActivityExecutor
 	inProcessNamePrefix string
+	payloadStore        payloadstore.Store
 }
 
 type ActivityExecutor interface {
 	ExecuteActivity(ctx context.Context, iid api.InstanceID, e *protos.HistoryEvent, opts ExecuteOptions) (*protos.HistoryEvent, error)
 }
 
-// NewActivityTaskWorker constructs an activity worker.
-func NewActivityTaskWorker(be Backend, executor ActivityExecutor, logger Logger, opts ...NewTaskWorkerOptions) TaskWorker[*ActivityWorkItem] {
-	processor := newActivityProcessor(be, executor, nil, "")
-	return NewTaskWorker(processor, logger, opts...)
+// ActivityWorkerOptions configures NewActivityWorker.
+type ActivityWorkerOptions struct {
+	Backend  Backend
+	Executor ActivityExecutor
+	Logger   Logger
+	// InProcessExecutor dispatches activities whose name has
+	// InProcessNamePrefix as a prefix; an empty prefix disables it.
+	InProcessExecutor   ActivityExecutor
+	InProcessNamePrefix string
+	// PayloadStore, when non-nil, resolves a payload-store reference in
+	// the activity input back to the payload before it is handed to the
+	// executor. Nil disables dereferencing.
+	PayloadStore payloadstore.Store
 }
 
-// NewActivityTaskWorkerWithInProcess constructs an activity worker that dispatches
-// activities whose name starts with inProcessNamePrefix to inProcessExecutor.
-// An empty prefix disables in-process dispatch.
-func NewActivityTaskWorkerWithInProcess(be Backend, executor, inProcessExecutor ActivityExecutor, inProcessNamePrefix string, logger Logger, opts ...NewTaskWorkerOptions) TaskWorker[*ActivityWorkItem] {
-	processor := newActivityProcessor(be, executor, inProcessExecutor, inProcessNamePrefix)
-	return NewTaskWorker(processor, logger, opts...)
-}
-
-func newActivityProcessor(be Backend, executor, inProcessExecutor ActivityExecutor, inProcessNamePrefix string) TaskProcessor[*ActivityWorkItem] {
-	return &activityProcessor{
-		be:                  be,
-		executor:            executor,
-		inProcessExecutor:   inProcessExecutor,
-		inProcessNamePrefix: inProcessNamePrefix,
+// NewActivityWorker constructs an activity worker.
+func NewActivityWorker(opts ActivityWorkerOptions, taskopts ...NewTaskWorkerOptions) TaskWorker[*ActivityWorkItem] {
+	processor := &activityProcessor{
+		be:                  opts.Backend,
+		executor:            opts.Executor,
+		inProcessExecutor:   opts.InProcessExecutor,
+		inProcessNamePrefix: opts.InProcessNamePrefix,
+		payloadStore:        opts.PayloadStore,
 	}
+	return NewTaskWorker(processor, opts.Logger, taskopts...)
 }
 
 // Name implements TaskProcessor
@@ -89,7 +95,21 @@ func (p *activityProcessor) ProcessWorkItem(ctx context.Context, awi *ActivityWo
 	if p.inProcessExecutor != nil && p.inProcessNamePrefix != "" && strings.HasPrefix(ts.GetName(), p.inProcessNamePrefix) {
 		executor = p.inProcessExecutor
 	}
-	result, err := executor.ExecuteActivity(ctx, awi.InstanceID, awi.NewEvent, execOpts)
+	// Resolve an offloaded input on a copy of the event so the executor
+	// sees the full payload while the work item keeps its reference.
+	event := awi.NewEvent
+	if p.payloadStore != nil {
+		events, derr := payloadstore.Dereference(ctx, p.payloadStore, string(awi.InstanceID), []*protos.HistoryEvent{event})
+		if derr != nil {
+			if span != nil {
+				span.RecordError(derr)
+				span.SetStatus(codes.Error, derr.Error())
+			}
+			return fmt.Errorf("failed to resolve offloaded activity input: %w", derr)
+		}
+		event = events[0]
+	}
+	result, err := executor.ExecuteActivity(ctx, awi.InstanceID, event, execOpts)
 	if err != nil {
 		if span != nil {
 			span.RecordError(err)

--- a/backend/client.go
+++ b/backend/client.go
@@ -141,11 +141,14 @@ func (c *backendClient) waitForWorkflowCondition(ctx context.Context, id api.Ins
 		metadata = m
 		return condition(m)
 	})
+	if err != nil {
+		return metadata, err
+	}
 
 	// Resolve once on the final metadata rather than on every status
 	// update observed while waiting.
 	resolveMetadataPayloads(ctx, c.payloadStore, c.logger, metadata)
-	return metadata, err
+	return metadata, nil
 }
 
 // TerminateWorkflow enqueues a message to terminate a running workflow, causing it to stop receiving new events and

--- a/backend/client.go
+++ b/backend/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/helpers"
 	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/payloadstore"
 )
 
 type TaskHubClient interface {
@@ -30,13 +31,33 @@ type TaskHubClient interface {
 }
 
 type backendClient struct {
-	be Backend
+	be           Backend
+	payloadStore payloadstore.Store
+	logger       Logger
 }
 
-func NewTaskHubClient(be Backend) TaskHubClient {
-	return &backendClient{
+// TaskHubClientOption configures NewTaskHubClient.
+type TaskHubClientOption func(*backendClient)
+
+// WithClientPayloadStore makes the client resolve offloaded payload
+// references in workflow metadata (FetchWorkflowMetadata and the
+// WaitForWorkflow* calls) back to full payloads, best-effort. Resolution
+// failures are logged through logger when non-nil.
+func WithClientPayloadStore(store payloadstore.Store, logger Logger) TaskHubClientOption {
+	return func(c *backendClient) {
+		c.payloadStore = store
+		c.logger = logger
+	}
+}
+
+func NewTaskHubClient(be Backend, opts ...TaskHubClientOption) TaskHubClient {
+	c := &backendClient{
 		be: be,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 func (c *backendClient) ScheduleNewWorkflow(ctx context.Context, workflow interface{}, opts ...api.NewWorkflowOptions) (api.InstanceID, error) {
@@ -92,6 +113,7 @@ func (c *backendClient) FetchWorkflowMetadata(ctx context.Context, id api.Instan
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch workflow metadata: %w", err)
 	}
+	resolveMetadataPayloads(ctx, c.payloadStore, c.logger, metadata)
 	return metadata, nil
 }
 
@@ -120,6 +142,9 @@ func (c *backendClient) waitForWorkflowCondition(ctx context.Context, id api.Ins
 		return condition(m)
 	})
 
+	// Resolve once on the final metadata rather than on every status
+	// update observed while waiting.
+	resolveMetadataPayloads(ctx, c.payloadStore, c.logger, metadata)
 	return metadata, err
 }
 

--- a/backend/deprecated.go
+++ b/backend/deprecated.go
@@ -82,3 +82,23 @@ func (c *backendClient) ResumeOrchestration(ctx context.Context, id api.Instance
 func (c *backendClient) PurgeOrchestrationState(ctx context.Context, id api.InstanceID, opts ...api.PurgeOptions) error {
 	return c.PurgeWorkflowState(ctx, id, opts...)
 }
+
+// Deprecated: Use NewActivityWorker instead.
+func NewActivityTaskWorker(be Backend, executor ActivityExecutor, logger Logger, opts ...NewTaskWorkerOptions) TaskWorker[*ActivityWorkItem] {
+	return NewActivityWorker(ActivityWorkerOptions{
+		Backend:  be,
+		Executor: executor,
+		Logger:   logger,
+	}, opts...)
+}
+
+// Deprecated: Use NewActivityWorker instead.
+func NewActivityTaskWorkerWithInProcess(be Backend, executor, inProcessExecutor ActivityExecutor, inProcessNamePrefix string, logger Logger, opts ...NewTaskWorkerOptions) TaskWorker[*ActivityWorkItem] {
+	return NewActivityWorker(ActivityWorkerOptions{
+		Backend:             be,
+		Executor:            executor,
+		InProcessExecutor:   inProcessExecutor,
+		InProcessNamePrefix: inProcessNamePrefix,
+		Logger:              logger,
+	}, opts...)
+}

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/helpers"
 	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/payloadstore"
 )
 
 var emptyCompleteTaskResponse = &protos.CompleteTaskResponse{}
@@ -61,6 +62,7 @@ type grpcExecutor struct {
 	streamShutdownChan       <-chan any
 	streamSendTimeout        *time.Duration
 	skipWaitForInstanceStart bool
+	payloadStore             payloadstore.Store
 }
 
 type grpcExecutorOptions func(g *grpcExecutor)
@@ -92,6 +94,15 @@ func WithOnGetWorkItemsDisconnectCallback(callback func(context.Context) error) 
 func WithStreamShutdownChannel(c <-chan any) grpcExecutorOptions {
 	return func(g *grpcExecutor) {
 		g.streamShutdownChan = c
+	}
+}
+
+// WithExecutorPayloadStore makes the executor resolve offloaded payload
+// references in workflow metadata responses (GetInstance and the
+// WaitForInstance* calls) back to full payloads, best-effort.
+func WithExecutorPayloadStore(store payloadstore.Store) grpcExecutorOptions {
+	return func(g *grpcExecutor) {
+		g.payloadStore = store
 	}
 }
 
@@ -466,6 +477,7 @@ func (g *grpcExecutor) GetInstance(ctx context.Context, req *protos.GetInstanceR
 		return &protos.GetInstanceResponse{Exists: false}, nil
 	}
 
+	resolveMetadataPayloads(ctx, g.payloadStore, g.logger, metadata)
 	return createGetInstanceResponse(req, metadata), nil
 }
 
@@ -676,6 +688,9 @@ func (g *grpcExecutor) waitForInstance(ctx context.Context, req *protos.GetInsta
 		return &protos.GetInstanceResponse{Exists: false}, nil
 	}
 
+	// Resolve once on the final metadata rather than on every status
+	// update observed while waiting.
+	resolveMetadataPayloads(ctx, g.payloadStore, g.logger, metadata)
 	return createGetInstanceResponse(req, metadata), nil
 }
 

--- a/backend/metadatapayloads.go
+++ b/backend/metadatapayloads.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backend
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/backend/payloadstore"
+)
+
+// resolveMetadataPayloads best-effort resolves offloaded payload
+// references in the metadata's input and output so metadata consumers
+// (queries, waiters) see full payloads. Resolution failures leave the
+// reference value in place instead of failing the read: metadata must
+// stay available even when the payload store cannot serve a reference,
+// e.g. a workflow terminally failed for carrying a forged reference must
+// still be observable as FAILED. This is deliberately laxer than the
+// execution path, where an unresolvable reference fails the work item.
+// The Input/Output pointers are replaced, never mutated, as they may
+// alias history events in backend-cached workflow state.
+func resolveMetadataPayloads(ctx context.Context, store payloadstore.Store, logger Logger, meta *WorkflowMetadata) {
+	if store == nil || meta == nil {
+		return
+	}
+
+	for _, field := range []**wrapperspb.StringValue{&meta.Input, &meta.Output} {
+		if *field == nil {
+			continue
+		}
+		resolved, ok, err := payloadstore.Resolve(ctx, store, meta.GetInstanceId(), (*field).GetValue())
+		if err != nil {
+			if logger != nil {
+				logger.Warnf("Failed to resolve offloaded payload in metadata of workflow '%s'; returning the reference: %v",
+					meta.GetInstanceId(), err)
+			}
+			continue
+		}
+		if ok {
+			*field = wrapperspb.String(resolved)
+		}
+	}
+}

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/helpers"
 	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/payloadstore"
 	"github.com/dapr/durabletask-go/backend/runtimestate"
 )
 
@@ -41,6 +42,10 @@ type WorkflowWorkerOptions struct {
 	// InProcessNamePrefix is the workflow-name prefix that selects InProcessExecutor.
 	// Empty string disables prefix-based dispatch.
 	InProcessNamePrefix string
+	// PayloadStore, when non-nil, resolves payload-store references in the
+	// history handed to the executor back to the payloads, so workflow
+	// code always sees full payloads. Nil disables dereferencing.
+	PayloadStore payloadstore.Store
 }
 
 type workflowProcessor struct {
@@ -48,6 +53,7 @@ type workflowProcessor struct {
 	executor            WorkflowExecutor
 	inProcessExecutor   WorkflowExecutor
 	inProcessNamePrefix string
+	payloadStore        payloadstore.Store
 	logger              Logger
 
 	applier *runtimestate.Applier
@@ -57,12 +63,13 @@ func NewWorkflowWorker(opts WorkflowWorkerOptions, taskopts ...NewTaskWorkerOpti
 	processor := &workflowProcessor{
 		be:                  opts.Backend,
 		executor:            opts.Executor,
+		payloadStore:        opts.PayloadStore,
 		inProcessExecutor:   opts.InProcessExecutor,
 		inProcessNamePrefix: opts.InProcessNamePrefix,
 		logger:              opts.Logger,
 		applier:             runtimestate.NewApplier(opts.AppID, opts.Namespace),
 	}
-	return NewTaskWorker[*WorkflowWorkItem](processor, opts.Logger, taskopts...)
+	return NewTaskWorker(processor, opts.Logger, taskopts...)
 }
 
 // Name implements TaskProcessor
@@ -121,7 +128,20 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 					executor = w.inProcessExecutor
 				}
 			}
-			results, err := executor.ExecuteWorkflow(ctx, wi.InstanceID, wi.State.OldEvents, wi.State.NewEvents, execOpts)
+			// Resolve offloaded payloads on copies of the events so the
+			// executor sees full payloads while the runtime state (which
+			// the backend persists, and may sign) keeps its references.
+			oldEvents, newEvents := wi.State.OldEvents, wi.State.NewEvents
+			if w.payloadStore != nil {
+				var derr error
+				if oldEvents, derr = payloadstore.Dereference(ctx, w.payloadStore, string(wi.InstanceID), oldEvents); derr != nil {
+					return fmt.Errorf("failed to resolve offloaded payloads: %w", derr)
+				}
+				if newEvents, derr = payloadstore.Dereference(ctx, w.payloadStore, string(wi.InstanceID), newEvents); derr != nil {
+					return fmt.Errorf("failed to resolve offloaded payloads: %w", derr)
+				}
+			}
+			results, err := executor.ExecuteWorkflow(ctx, wi.InstanceID, oldEvents, newEvents, execOpts)
 			if err != nil {
 				return fmt.Errorf("error executing workflow: %w", err)
 			}

--- a/backend/payloadstore/codec.go
+++ b/backend/payloadstore/codec.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payloadstore
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// refMagic marks a payload string as an encoded Reference. References
+// live in-band in the same proto3 string fields that carry user payloads,
+// so the magic must make confusing user data for a reference practically
+// impossible:
+//
+//   - Payload fields are proto3 strings and therefore always valid UTF-8,
+//     for user payloads and encoded references alike. The magic uses only
+//     single-byte control characters, which are valid UTF-8, so encoded
+//     references survive proto marshaling.
+//   - The leading NUL cannot occur at the start of any JSON, XML, or other
+//     textual payload, and the full 38-byte sequence must match exactly.
+//     An accidental false positive requires user data to begin with this
+//     precise control-byte-framed sequence, which does not occur in
+//     natural data.
+//   - A payload deliberately crafted to look like a reference is skipped
+//     by the offload pass and persisted verbatim, exactly as the sender
+//     wrote it. Dereferencing it later either fails (unknown key or
+//     checksum mismatch, failing only that workflow) or returns bytes
+//     whose SHA-256 the sender already knew, so no new information is
+//     disclosed. Stores can additionally partition payloads by the
+//     instanceID given to Put to rule out cross-instance addressing.
+const refMagic = "\x00\x01dapr.workflow.payload.reference.v1\x01\x00"
+
+// ErrNotReference is returned by DecodeReference when the value does not
+// carry the reference magic prefix, i.e. it is ordinary user payload data.
+// Any other error means the value claims to be a reference but is corrupt.
+var ErrNotReference = errors.New("payload is not an encoded payload-store reference")
+
+// refJSON is the wire form of a Reference following the magic prefix. The
+// checksum is base64-encoded to keep the whole encoding valid UTF-8.
+type refJSON struct {
+	Key      string `json:"k"`
+	Checksum string `json:"c"`
+	Size     uint64 `json:"s"`
+}
+
+// EncodeReference renders ref as an in-band string that IsReference
+// detects and DecodeReference parses. The output is deterministic and
+// valid UTF-8, safe for proto3 string payload fields.
+func EncodeReference(ref Reference) string {
+	body, err := json.Marshal(refJSON{
+		Key:      ref.Key,
+		Checksum: base64.RawStdEncoding.EncodeToString(ref.Checksum[:]),
+		Size:     ref.Size,
+	})
+	if err != nil {
+		// json.Marshal of a struct of string/uint64 fields cannot fail.
+		panic(fmt.Sprintf("payloadstore: failed to marshal reference: %v", err))
+	}
+	return refMagic + string(body)
+}
+
+// IsReference cheaply reports whether s carries the reference magic
+// prefix. A true result does not guarantee the reference is well formed;
+// use DecodeReference for a strict parse.
+func IsReference(s string) bool {
+	return strings.HasPrefix(s, refMagic)
+}
+
+// DecodeReference strictly parses an encoded Reference. It returns
+// ErrNotReference when s has no magic prefix (ordinary user data), and a
+// descriptive error when the magic is present but the body is malformed
+// (a corrupt or forged reference).
+func DecodeReference(s string) (Reference, error) {
+	if !IsReference(s) {
+		return Reference{}, ErrNotReference
+	}
+
+	raw := s[len(refMagic):]
+	var body refJSON
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
+		return Reference{}, fmt.Errorf("malformed payload-store reference body: %w", err)
+	}
+	// The body must be exactly one JSON value with nothing after it, not
+	// even whitespace (which EncodeReference never emits): the decode must
+	// have consumed every byte.
+	if dec.InputOffset() != int64(len(raw)) {
+		return Reference{}, errors.New("malformed payload-store reference body: trailing data")
+	}
+
+	checksum, err := base64.RawStdEncoding.DecodeString(body.Checksum)
+	if err != nil {
+		return Reference{}, fmt.Errorf("malformed payload-store reference checksum: %w", err)
+	}
+
+	ref := Reference{
+		Key:  body.Key,
+		Size: body.Size,
+	}
+	if len(checksum) != len(ref.Checksum) {
+		return Reference{}, fmt.Errorf("malformed payload-store reference checksum: got %d bytes, want %d", len(checksum), len(ref.Checksum))
+	}
+	copy(ref.Checksum[:], checksum)
+
+	return ref, nil
+}

--- a/backend/payloadstore/codec_test.go
+++ b/backend/payloadstore/codec_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payloadstore
+
+import (
+	"crypto/sha256"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+func testRef(t *testing.T, data string) Reference {
+	t.Helper()
+	return Reference{
+		Checksum: sha256.Sum256([]byte(data)),
+		Key:      "test-key/" + data,
+		Size:     uint64(len(data)),
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ref := testRef(t, "some payload")
+
+	encoded := EncodeReference(ref)
+	assert.True(t, IsReference(encoded))
+
+	decoded, err := DecodeReference(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, ref, decoded)
+}
+
+func TestIsReferenceRejectsUserData(t *testing.T) {
+	t.Parallel()
+
+	encoded := EncodeReference(testRef(t, "x"))
+
+	for name, payload := range map[string]string{
+		"empty":                     "",
+		"plain text":                "hello world",
+		"json":                      `{"k":"a","c":"b","s":1}`,
+		"json array":                `[1,2,3]`,
+		"leading NUL only":          "\x00hello",
+		"leading control chars":     "\x00\x01\x02data",
+		"truncated magic":           encoded[:3],
+		"ref embedded mid-string":   "prefix" + encoded,
+		"magic-like ascii":          "dapr.workflow.payload.reference.v1",
+		"control chars not magic":   "\x1f\x1e\x1d\x00\x01\x02",
+		"multibyte utf8":            "päylöad ☃ работа",
+		"almost magic then diverge": encoded[:8] + "ZZZZZZZZ",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.False(t, IsReference(payload))
+
+			_, err := DecodeReference(payload)
+			require.ErrorIs(t, err, ErrNotReference)
+		})
+	}
+}
+
+func TestDecodeReferenceCorruptBody(t *testing.T) {
+	t.Parallel()
+
+	encoded := EncodeReference(testRef(t, "x"))
+	// Recover the magic prefix by stripping the JSON body.
+	magic := encoded[:strings.IndexByte(encoded, '{')]
+	require.NotEmpty(t, magic)
+
+	for name, payload := range map[string]string{
+		"magic only":                magic,
+		"magic plus garbage":        magic + "not json",
+		"magic empty json":          magic + "{}",
+		"invalid checksum encoding": magic + `{"k":"a","c":"!!!","s":1}`,
+		"short checksum":            magic + `{"k":"a","c":"zz","s":1}`,
+		"truncated body":            encoded[:len(encoded)-2],
+		"trailing bytes":            encoded + "x",
+		"trailing whitespace":       encoded + " ",
+		"trailing newline":          encoded + "\n",
+		"trailing json value":       encoded + `{"k":"b"}`,
+		"checksum wrong type":       magic + `{"k":"a","c":42,"s":1}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// The magic prefix is present, so the cheap detector fires...
+			assert.True(t, IsReference(payload))
+
+			// ...but a strict decode must fail, and NOT with ErrNotReference:
+			// this is a corrupt/forged reference, not user data.
+			_, err := DecodeReference(payload)
+			require.Error(t, err)
+			assert.NotErrorIs(t, err, ErrNotReference)
+		})
+	}
+}
+
+// An encoded reference is stored in proto3 string fields
+// (wrapperspb.StringValue), which require valid UTF-8. Marshal fails on
+// invalid UTF-8, so this round trip proves the encoding is wire-safe.
+func TestEncodedReferenceIsValidProtoString(t *testing.T) {
+	t.Parallel()
+
+	encoded := EncodeReference(testRef(t, "wire safety"))
+
+	e := &protos.HistoryEvent{
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				Result: wrapperspb.String(encoded),
+			},
+		},
+	}
+
+	data, err := proto.Marshal(e)
+	require.NoError(t, err)
+
+	var got protos.HistoryEvent
+	require.NoError(t, proto.Unmarshal(data, &got))
+	assert.Equal(t, encoded, got.GetTaskCompleted().GetResult().GetValue())
+}

--- a/backend/payloadstore/dereference.go
+++ b/backend/payloadstore/dereference.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payloadstore
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+// maxConcurrentGets bounds the store reads issued in parallel for one
+// dereference pass. A long history replayed cold can carry many
+// references; the bound keeps the fan-out to the store reasonable.
+const maxConcurrentGets = 8
+
+// Dereference returns events with every payload-store reference resolved
+// back to its payload, ready to hand to workflow or activity code. The
+// input events are never mutated: they alias the backend's cached,
+// persisted (and possibly signed) state, so reference-carrying events are
+// replaced by clones with the payload inlined while all other events pass
+// through by pointer. When no event carries a reference the input slice
+// is returned as-is.
+//
+// Values that carry the reference magic but fail a strict decode are user
+// data the offload pass persisted verbatim, and pass through unchanged.
+//
+// The payload bytes returned by the store are re-verified against the
+// reference's checksum and size here, regardless of the store's own
+// mandatory verification, so a misbehaving store cannot feed the workflow
+// payload bytes that do not match the (typically signed) reference.
+func Dereference(ctx context.Context, store Store, instanceID string, events []*protos.HistoryEvent) ([]*protos.HistoryEvent, error) {
+	// Find the events to resolve sequentially - the scan is cheap - then
+	// fan out the store reads, which may be remote I/O.
+	type job struct {
+		idx int
+		ref Reference
+	}
+	var jobs []job
+	for i, e := range events {
+		p := Payload(e)
+		if p == nil {
+			continue
+		}
+		ref, err := DecodeReference(p.GetValue())
+		if err != nil {
+			continue
+		}
+		jobs = append(jobs, job{idx: i, ref: ref})
+	}
+	if len(jobs) == 0 {
+		return events, nil
+	}
+
+	out := make([]*protos.HistoryEvent, len(events))
+	copy(out, events)
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxConcurrentGets)
+	for _, j := range jobs {
+		eg.Go(func() error {
+			data, err := fetchVerified(egCtx, store, instanceID, j.ref)
+			if err != nil {
+				return fmt.Errorf("failed to resolve payload of event %d: %w", events[j.idx].GetEventId(), err)
+			}
+
+			clone := proto.CloneOf(events[j.idx])
+			Payload(clone).Value = string(data)
+			out[j.idx] = clone
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// Resolve returns the payload for s when it encodes a payload-store
+// reference, reporting whether a resolution happened. Ordinary user data
+// (including values that carry the reference magic but fail a strict
+// decode, which the offload pass persists verbatim) is returned
+// unchanged. Use it for single payload values outside of history events,
+// such as the input/output fields of workflow metadata.
+func Resolve(ctx context.Context, store Store, instanceID, s string) (string, bool, error) {
+	ref, err := DecodeReference(s)
+	if err != nil {
+		return s, false, nil
+	}
+
+	data, err := fetchVerified(ctx, store, instanceID, ref)
+	if err != nil {
+		return "", false, err
+	}
+	return string(data), true, nil
+}
+
+// fetchVerified reads a payload from the store and re-verifies it against
+// the reference's checksum and size, regardless of the store's own
+// mandatory verification, so a misbehaving store cannot return payload
+// bytes that do not match the (typically signed) reference.
+func fetchVerified(ctx context.Context, store Store, instanceID string, ref Reference) ([]byte, error) {
+	data, err := store.Get(ctx, instanceID, ref)
+	if err != nil {
+		return nil, err
+	}
+	if sha256.Sum256(data) != ref.Checksum || uint64(len(data)) != ref.Size {
+		return nil, fmt.Errorf("payload for key '%s' failed checksum verification against its reference", ref.Key)
+	}
+	return data, nil
+}

--- a/backend/payloadstore/dereference.go
+++ b/backend/payloadstore/dereference.go
@@ -45,6 +45,11 @@ const maxConcurrentGets = 8
 // mandatory verification, so a misbehaving store cannot feed the workflow
 // payload bytes that do not match the (typically signed) reference.
 func Dereference(ctx context.Context, store Store, instanceID string, events []*protos.HistoryEvent) ([]*protos.HistoryEvent, error) {
+	// A nil store disables the feature: references pass through unresolved.
+	if store == nil {
+		return events, nil
+	}
+
 	// Find the events to resolve sequentially - the scan is cheap - then
 	// fan out the store reads, which may be remote I/O.
 	type job struct {
@@ -99,6 +104,11 @@ func Dereference(ctx context.Context, store Store, instanceID string, events []*
 // unchanged. Use it for single payload values outside of history events,
 // such as the input/output fields of workflow metadata.
 func Resolve(ctx context.Context, store Store, instanceID, s string) (string, bool, error) {
+	// A nil store disables the feature: references pass through unresolved.
+	if store == nil {
+		return s, false, nil
+	}
+
 	ref, err := DecodeReference(s)
 	if err != nil {
 		return s, false, nil

--- a/backend/payloadstore/dereference_test.go
+++ b/backend/payloadstore/dereference_test.go
@@ -231,3 +231,31 @@ func TestResolve(t *testing.T) {
 		require.ErrorContains(t, err, "checksum")
 	})
 }
+
+// A nil store disables the feature entirely: references pass through
+// unresolved instead of panicking, per the package contract.
+func TestDereferenceNilStore(t *testing.T) {
+	t.Parallel()
+
+	backing := fake.New()
+	events := []*protos.HistoryEvent{offloaded(t, backing, 0, "payload")}
+	encoded := events[0].GetTaskCompleted().GetResult().GetValue()
+
+	out, err := payloadstore.Dereference(t.Context(), nil, "wf1", events)
+	require.NoError(t, err)
+	assert.Equal(t, encoded, out[0].GetTaskCompleted().GetResult().GetValue())
+}
+
+func TestResolveNilStore(t *testing.T) {
+	t.Parallel()
+
+	backing := fake.New()
+	ref, err := backing.Put(t.Context(), "wf1", []byte("payload"))
+	require.NoError(t, err)
+	encoded := payloadstore.EncodeReference(ref)
+
+	got, resolved, err := payloadstore.Resolve(t.Context(), nil, "wf1", encoded)
+	require.NoError(t, err)
+	assert.False(t, resolved)
+	assert.Equal(t, encoded, got)
+}

--- a/backend/payloadstore/dereference_test.go
+++ b/backend/payloadstore/dereference_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payloadstore_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/payloadstore"
+	"github.com/dapr/durabletask-go/backend/payloadstore/fake"
+)
+
+func resultEvent(id int32, result string) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId: id,
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: id,
+				Result:          wrapperspb.String(result),
+			},
+		},
+	}
+}
+
+// offloaded stores payload and returns an event whose payload field
+// carries the resulting reference.
+func offloaded(t *testing.T, store payloadstore.Store, id int32, payload string) *protos.HistoryEvent {
+	t.Helper()
+	ref, err := store.Put(t.Context(), "wf1", []byte(payload))
+	require.NoError(t, err)
+	return resultEvent(id, payloadstore.EncodeReference(ref))
+}
+
+func TestDereferenceRestoresPayloads(t *testing.T) {
+	t.Parallel()
+
+	store := fake.New()
+	const big = "a large offloaded payload"
+	const small = "inline"
+
+	events := []*protos.HistoryEvent{
+		offloaded(t, store, 0, big),
+		resultEvent(1, small),
+		{EventId: 2, EventType: &protos.HistoryEvent_TimerFired{TimerFired: &protos.TimerFiredEvent{}}},
+	}
+
+	out, err := payloadstore.Dereference(t.Context(), store, "wf1", events)
+	require.NoError(t, err)
+	require.Len(t, out, len(events))
+
+	assert.Equal(t, big, out[0].GetTaskCompleted().GetResult().GetValue())
+	assert.Equal(t, small, out[1].GetTaskCompleted().GetResult().GetValue())
+	assert.Same(t, events[2], out[2], "events without payloads pass through untouched")
+	assert.Same(t, events[1], out[1], "inline events pass through untouched")
+}
+
+// TestDereferenceDoesNotMutateOriginals pins the copy-on-write contract:
+// the input events alias the backend's cached, persisted (and possibly
+// signed) state, so the reference-carrying originals must stay intact.
+func TestDereferenceDoesNotMutateOriginals(t *testing.T) {
+	t.Parallel()
+
+	store := fake.New()
+	events := []*protos.HistoryEvent{offloaded(t, store, 0, "payload")}
+	encoded := events[0].GetTaskCompleted().GetResult().GetValue()
+
+	out, err := payloadstore.Dereference(t.Context(), store, "wf1", events)
+	require.NoError(t, err)
+
+	assert.NotSame(t, events[0], out[0], "reference-carrying events must be cloned")
+	assert.Equal(t, encoded, events[0].GetTaskCompleted().GetResult().GetValue(),
+		"the original event must keep its reference")
+	assert.Equal(t, "payload", out[0].GetTaskCompleted().GetResult().GetValue())
+}
+
+func TestDereferenceNoReferencesReturnsInput(t *testing.T) {
+	t.Parallel()
+
+	events := []*protos.HistoryEvent{resultEvent(0, "inline")}
+	out, err := payloadstore.Dereference(t.Context(), fake.New(), "wf1", events)
+	require.NoError(t, err)
+	assert.Same(t, &events[0], &out[0], "no references: the input slice is returned as-is")
+}
+
+// A value carrying the magic prefix but failing a strict decode is user
+// data persisted verbatim by the offload pass, and passes through as-is.
+func TestDereferenceMalformedMagicPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	store := fake.New()
+	crafted := payloadstore.EncodeReference(payloadstore.Reference{Key: "x"})
+	corrupt := crafted[:len(crafted)-2] + "garbage"
+	events := []*protos.HistoryEvent{resultEvent(0, corrupt)}
+
+	out, err := payloadstore.Dereference(t.Context(), store, "wf1", events)
+	require.NoError(t, err)
+	assert.Equal(t, corrupt, out[0].GetTaskCompleted().GetResult().GetValue())
+}
+
+func TestDereferenceGetFailure(t *testing.T) {
+	t.Parallel()
+
+	errGet := errors.New("store unavailable")
+	store := fake.New()
+	events := []*protos.HistoryEvent{offloaded(t, store, 7, "payload")}
+
+	failing := fake.New().WithGetFn(func(context.Context, string, payloadstore.Reference) ([]byte, error) {
+		return nil, errGet
+	})
+
+	_, err := payloadstore.Dereference(t.Context(), failing, "wf1", events)
+	require.ErrorIs(t, err, errGet)
+}
+
+// TestDereferenceVerifiesChecksum pins the engine-side defense in depth:
+// even if a store implementation skips the mandatory checksum check, the
+// engine refuses payload bytes that do not match the signed reference.
+func TestDereferenceVerifiesChecksum(t *testing.T) {
+	t.Parallel()
+
+	store := fake.New()
+	events := []*protos.HistoryEvent{offloaded(t, store, 0, "original")}
+
+	sloppy := fake.New().WithGetFn(func(context.Context, string, payloadstore.Reference) ([]byte, error) {
+		return []byte("tampered"), nil
+	})
+
+	_, err := payloadstore.Dereference(t.Context(), sloppy, "wf1", events)
+	require.ErrorContains(t, err, "checksum")
+}
+
+func TestDereferenceManyEvents(t *testing.T) {
+	t.Parallel()
+
+	store := fake.New()
+	const n = 24
+	events := make([]*protos.HistoryEvent, n)
+	payloads := make([]string, n)
+	for i := range events {
+		payloads[i] = fmt.Sprintf("payload-%02d-", i) + strings.Repeat("p", 64)
+		events[i] = offloaded(t, store, int32(i), payloads[i]) //nolint:gosec
+	}
+
+	out, err := payloadstore.Dereference(t.Context(), store, "wf1", events)
+	require.NoError(t, err)
+	for i := range out {
+		assert.Equal(t, payloads[i], out[i].GetTaskCompleted().GetResult().GetValue())
+	}
+}
+
+// Checksums in references are computed over the payload bytes; sanity
+// check the fixture helper produces resolvable references.
+func TestDereferenceFixtureSanity(t *testing.T) {
+	t.Parallel()
+
+	store := fake.New()
+	e := offloaded(t, store, 0, "abc")
+	ref, err := payloadstore.DecodeReference(e.GetTaskCompleted().GetResult().GetValue())
+	require.NoError(t, err)
+	assert.Equal(t, sha256.Sum256([]byte("abc")), ref.Checksum)
+}
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	store := fake.New()
+	ref, err := store.Put(t.Context(), "wf1", []byte("payload"))
+	require.NoError(t, err)
+	encoded := payloadstore.EncodeReference(ref)
+
+	t.Run("resolves a reference", func(t *testing.T) {
+		t.Parallel()
+		got, resolved, err := payloadstore.Resolve(t.Context(), store, "wf1", encoded)
+		require.NoError(t, err)
+		assert.True(t, resolved)
+		assert.Equal(t, "payload", got)
+	})
+
+	t.Run("passes user data through", func(t *testing.T) {
+		t.Parallel()
+		got, resolved, err := payloadstore.Resolve(t.Context(), store, "wf1", "plain user data")
+		require.NoError(t, err)
+		assert.False(t, resolved)
+		assert.Equal(t, "plain user data", got)
+	})
+
+	t.Run("passes malformed magic-prefixed data through", func(t *testing.T) {
+		t.Parallel()
+		corrupt := encoded[:len(encoded)-2] + "garbage"
+		got, resolved, err := payloadstore.Resolve(t.Context(), store, "wf1", corrupt)
+		require.NoError(t, err)
+		assert.False(t, resolved)
+		assert.Equal(t, corrupt, got)
+	})
+
+	t.Run("get failure surfaces", func(t *testing.T) {
+		t.Parallel()
+		failing := fake.New().WithGetFn(func(context.Context, string, payloadstore.Reference) ([]byte, error) {
+			return nil, errors.New("store unavailable")
+		})
+		_, _, err := payloadstore.Resolve(t.Context(), failing, "wf1", encoded)
+		require.ErrorContains(t, err, "store unavailable")
+	})
+
+	t.Run("checksum mismatch surfaces", func(t *testing.T) {
+		t.Parallel()
+		sloppy := fake.New().WithGetFn(func(context.Context, string, payloadstore.Reference) ([]byte, error) {
+			return []byte("tampered"), nil
+		})
+		_, _, err := payloadstore.Resolve(t.Context(), sloppy, "wf1", encoded)
+		require.ErrorContains(t, err, "checksum")
+	})
+}

--- a/backend/payloadstore/fake/fake.go
+++ b/backend/payloadstore/fake/fake.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fake provides an in-memory payloadstore.Store for tests. It is
+// also the reference implementation of the Store contract: content-
+// addressed keys, idempotent Put, and mandatory checksum verification on
+// Get. It is never wired into the runtime.
+package fake
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+
+	"github.com/dapr/durabletask-go/backend/payloadstore"
+)
+
+type Fake struct {
+	lock      sync.Mutex
+	data      map[string][]byte
+	putCalls  int
+	threshold int
+
+	putFn func(ctx context.Context, instanceID string, data []byte) (payloadstore.Reference, error)
+	getFn func(ctx context.Context, instanceID string, ref payloadstore.Reference) ([]byte, error)
+}
+
+func New() *Fake {
+	f := &Fake{
+		data:      make(map[string][]byte),
+		threshold: payloadstore.DefaultThreshold,
+	}
+	f.putFn = f.defaultPut
+	f.getFn = f.defaultGet
+	return f
+}
+
+// WithThreshold sets the size in bytes at or above which ShouldOffload
+// reports true.
+func (f *Fake) WithThreshold(threshold int) *Fake {
+	f.threshold = threshold
+	return f
+}
+
+func (f *Fake) WithPutFn(fn func(ctx context.Context, instanceID string, data []byte) (payloadstore.Reference, error)) *Fake {
+	f.putFn = fn
+	return f
+}
+
+func (f *Fake) WithGetFn(fn func(ctx context.Context, instanceID string, ref payloadstore.Reference) ([]byte, error)) *Fake {
+	f.getFn = fn
+	return f
+}
+
+func (f *Fake) ShouldOffload(size int) bool {
+	return size >= f.threshold
+}
+
+func (f *Fake) Put(ctx context.Context, instanceID string, data []byte) (payloadstore.Reference, error) {
+	f.lock.Lock()
+	f.putCalls++
+	f.lock.Unlock()
+	return f.putFn(ctx, instanceID, data)
+}
+
+func (f *Fake) Get(ctx context.Context, instanceID string, ref payloadstore.Reference) ([]byte, error) {
+	return f.getFn(ctx, instanceID, ref)
+}
+
+// PutCalls returns how many times Put has been invoked, including calls
+// served by an injected putFn.
+func (f *Fake) PutCalls() int {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	return f.putCalls
+}
+
+// Tamper overwrites the payload stored under key without updating any
+// reference, so a subsequent Get through a reference with the original
+// checksum must fail verification.
+func (f *Fake) Tamper(key string, data []byte) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.data[key] = data
+}
+
+func (f *Fake) defaultPut(_ context.Context, _ string, data []byte) (payloadstore.Reference, error) {
+	checksum := sha256.Sum256(data)
+	key := hex.EncodeToString(checksum[:])
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	stored := make([]byte, len(data))
+	copy(stored, data)
+	f.data[key] = stored
+
+	return payloadstore.Reference{
+		Checksum: checksum,
+		Key:      key,
+		Size:     uint64(len(data)),
+	}, nil
+}
+
+func (f *Fake) defaultGet(_ context.Context, _ string, ref payloadstore.Reference) ([]byte, error) {
+	f.lock.Lock()
+	data, ok := f.data[ref.Key]
+	f.lock.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("payload not found for key '%s'", ref.Key)
+	}
+
+	if sha256.Sum256(data) != ref.Checksum {
+		return nil, fmt.Errorf("payload checksum mismatch for key '%s': stored data does not match reference checksum", ref.Key)
+	}
+
+	// Defensive copy: callers own the returned slice and must not be able
+	// to mutate the stored payload through it.
+	out := make([]byte, len(data))
+	copy(out, data)
+	return out, nil
+}

--- a/backend/payloadstore/fake/fake_test.go
+++ b/backend/payloadstore/fake/fake_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/durabletask-go/backend/payloadstore"
+)
+
+func TestShouldOffload(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults to DefaultThreshold", func(t *testing.T) {
+		t.Parallel()
+		f := New()
+		assert.False(t, f.ShouldOffload(payloadstore.DefaultThreshold-1))
+		assert.True(t, f.ShouldOffload(payloadstore.DefaultThreshold))
+	})
+
+	t.Run("configured threshold, at-or-above semantics", func(t *testing.T) {
+		t.Parallel()
+		f := New().WithThreshold(10)
+		assert.False(t, f.ShouldOffload(9))
+		assert.True(t, f.ShouldOffload(10))
+		assert.True(t, f.ShouldOffload(11))
+	})
+}
+
+func TestPutGetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	f := New()
+	data := []byte("a large workflow payload")
+
+	ref, err := f.Put(t.Context(), "instance-1", data)
+	require.NoError(t, err)
+	assert.Equal(t, sha256.Sum256(data), ref.Checksum)
+	assert.Equal(t, uint64(len(data)), ref.Size)
+	assert.NotEmpty(t, ref.Key)
+
+	got, err := f.Get(t.Context(), "instance-1", ref)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestPutIsIdempotentForIdenticalData(t *testing.T) {
+	t.Parallel()
+
+	f := New()
+	data := []byte("same bytes")
+
+	ref1, err := f.Put(t.Context(), "instance-1", data)
+	require.NoError(t, err)
+	ref2, err := f.Put(t.Context(), "instance-1", data)
+	require.NoError(t, err)
+
+	assert.Equal(t, ref1, ref2)
+	assert.Equal(t, 2, f.PutCalls())
+}
+
+func TestGetUnknownReference(t *testing.T) {
+	t.Parallel()
+
+	f := New()
+	_, err := f.Get(t.Context(), "instance-1", payloadstore.Reference{Key: "no-such-key"})
+	require.Error(t, err)
+}
+
+func TestGetReturnsDefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	f := New()
+	ref, err := f.Put(t.Context(), "instance-1", []byte("original data"))
+	require.NoError(t, err)
+
+	got, err := f.Get(t.Context(), "instance-1", ref)
+	require.NoError(t, err)
+	for i := range got {
+		got[i] = 'X'
+	}
+
+	// Mutating the returned slice must not corrupt the stored payload.
+	again, err := f.Get(t.Context(), "instance-1", ref)
+	require.NoError(t, err)
+	assert.Equal(t, "original data", string(again))
+}
+
+func TestGetDetectsTamperedData(t *testing.T) {
+	t.Parallel()
+
+	f := New()
+	ref, err := f.Put(t.Context(), "instance-1", []byte("original data"))
+	require.NoError(t, err)
+
+	f.Tamper(ref.Key, []byte("tampered data"))
+
+	_, err = f.Get(t.Context(), "instance-1", ref)
+	require.ErrorContains(t, err, "checksum")
+}
+
+func TestErrorInjection(t *testing.T) {
+	t.Parallel()
+
+	errPut := errors.New("put exploded")
+	errGet := errors.New("get exploded")
+
+	f := New().
+		WithPutFn(func(context.Context, string, []byte) (payloadstore.Reference, error) {
+			return payloadstore.Reference{}, errPut
+		}).
+		WithGetFn(func(context.Context, string, payloadstore.Reference) ([]byte, error) {
+			return nil, errGet
+		})
+
+	_, err := f.Put(t.Context(), "instance-1", []byte("x"))
+	require.ErrorIs(t, err, errPut)
+
+	_, err = f.Get(t.Context(), "instance-1", payloadstore.Reference{})
+	require.ErrorIs(t, err, errGet)
+}

--- a/backend/payloadstore/payload.go
+++ b/backend/payloadstore/payload.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payloadstore
+
+import (
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+// Payload returns the user-payload field of e, or nil when the event type
+// carries no user payload or the field is unset. It is the single
+// enumeration of payload-bearing history event types: the offload pass
+// and any dereference hook must both go through it so they can never
+// disagree on which fields hold payloads. Callers read and mutate the
+// returned StringValue's Value in place.
+//
+// Deliberately excluded: TaskFailureDetails (error message and stack
+// trace on failure events) is structured diagnostic data, not a user
+// payload, and version/span-ID StringValue fields are small system
+// metadata. TestPayloadAccessorCompleteness enforces that every other
+// StringValue field on a HistoryEvent variant is covered here.
+func Payload(e *protos.HistoryEvent) *wrapperspb.StringValue {
+	switch typed := e.GetEventType().(type) {
+	case *protos.HistoryEvent_ExecutionStarted:
+		return typed.ExecutionStarted.GetInput()
+	case *protos.HistoryEvent_ExecutionCompleted:
+		return typed.ExecutionCompleted.GetResult()
+	case *protos.HistoryEvent_ExecutionTerminated:
+		return typed.ExecutionTerminated.GetInput()
+	case *protos.HistoryEvent_TaskScheduled:
+		return typed.TaskScheduled.GetInput()
+	case *protos.HistoryEvent_TaskCompleted:
+		return typed.TaskCompleted.GetResult()
+	case *protos.HistoryEvent_ChildWorkflowInstanceCreated:
+		return typed.ChildWorkflowInstanceCreated.GetInput()
+	case *protos.HistoryEvent_ChildWorkflowInstanceCompleted:
+		return typed.ChildWorkflowInstanceCompleted.GetResult()
+	case *protos.HistoryEvent_EventSent:
+		return typed.EventSent.GetInput()
+	case *protos.HistoryEvent_EventRaised:
+		return typed.EventRaised.GetInput()
+	case *protos.HistoryEvent_ContinueAsNew:
+		return typed.ContinueAsNew.GetInput()
+	case *protos.HistoryEvent_ExecutionSuspended:
+		return typed.ExecutionSuspended.GetInput()
+	case *protos.HistoryEvent_ExecutionResumed:
+		return typed.ExecutionResumed.GetInput()
+	default:
+		return nil
+	}
+}

--- a/backend/payloadstore/payload_test.go
+++ b/backend/payloadstore/payload_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payloadstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+func TestPayloadReturnsFieldForEveryPayloadBearingEventType(t *testing.T) {
+	t.Parallel()
+
+	const marker = "payload-marker"
+
+	for name, e := range map[string]*protos.HistoryEvent{
+		"ExecutionStarted": {EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{Input: wrapperspb.String(marker)},
+		}},
+		"ExecutionCompleted": {EventType: &protos.HistoryEvent_ExecutionCompleted{
+			ExecutionCompleted: &protos.ExecutionCompletedEvent{Result: wrapperspb.String(marker)},
+		}},
+		"ExecutionTerminated": {EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{Input: wrapperspb.String(marker)},
+		}},
+		"TaskScheduled": {EventType: &protos.HistoryEvent_TaskScheduled{
+			TaskScheduled: &protos.TaskScheduledEvent{Input: wrapperspb.String(marker)},
+		}},
+		"TaskCompleted": {EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{Result: wrapperspb.String(marker)},
+		}},
+		"ChildWorkflowInstanceCreated": {EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{
+			ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{Input: wrapperspb.String(marker)},
+		}},
+		"ChildWorkflowInstanceCompleted": {EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{Result: wrapperspb.String(marker)},
+		}},
+		"EventSent": {EventType: &protos.HistoryEvent_EventSent{
+			EventSent: &protos.EventSentEvent{Input: wrapperspb.String(marker)},
+		}},
+		"EventRaised": {EventType: &protos.HistoryEvent_EventRaised{
+			EventRaised: &protos.EventRaisedEvent{Input: wrapperspb.String(marker)},
+		}},
+		"ContinueAsNew": {EventType: &protos.HistoryEvent_ContinueAsNew{
+			ContinueAsNew: &protos.ContinueAsNewEvent{Input: wrapperspb.String(marker)},
+		}},
+		"ExecutionSuspended": {EventType: &protos.HistoryEvent_ExecutionSuspended{
+			ExecutionSuspended: &protos.ExecutionSuspendedEvent{Input: wrapperspb.String(marker)},
+		}},
+		"ExecutionResumed": {EventType: &protos.HistoryEvent_ExecutionResumed{
+			ExecutionResumed: &protos.ExecutionResumedEvent{Input: wrapperspb.String(marker)},
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			p := Payload(e)
+			require.NotNil(t, p)
+			assert.Equal(t, marker, p.GetValue())
+
+			// Callers mutate the returned field in place; the event must
+			// observe the change on the wire.
+			p.Value = "mutated"
+			data, err := proto.Marshal(e)
+			require.NoError(t, err)
+			assert.Contains(t, string(data), "mutated")
+			assert.NotContains(t, string(data), marker)
+		})
+	}
+}
+
+func TestPayloadNilWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	for name, e := range map[string]*protos.HistoryEvent{
+		"nil event":     nil,
+		"no event type": {},
+		"timer created": {EventType: &protos.HistoryEvent_TimerCreated{TimerCreated: &protos.TimerCreatedEvent{}}},
+		"timer fired":   {EventType: &protos.HistoryEvent_TimerFired{TimerFired: &protos.TimerFiredEvent{}}},
+		"workflow started": {EventType: &protos.HistoryEvent_WorkflowStarted{
+			WorkflowStarted: &protos.WorkflowStartedEvent{},
+		}},
+		"task failed": {EventType: &protos.HistoryEvent_TaskFailed{
+			TaskFailed: &protos.TaskFailedEvent{FailureDetails: &protos.TaskFailureDetails{ErrorMessage: "boom"}},
+		}},
+		"child workflow failed": {EventType: &protos.HistoryEvent_ChildWorkflowInstanceFailed{
+			ChildWorkflowInstanceFailed: &protos.ChildWorkflowInstanceFailedEvent{},
+		}},
+		"payload field unset": {EventType: &protos.HistoryEvent_TaskScheduled{
+			TaskScheduled: &protos.TaskScheduledEvent{Name: "act"},
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Nil(t, Payload(e))
+		})
+	}
+}
+
+// TestPayloadAccessorCompleteness walks every HistoryEvent oneof variant
+// via protoreflect and fails if a variant carries a StringValue field the
+// accessor does not expose. This catches durabletask-go proto upgrades
+// that add payload-bearing event types or fields: on failure, either add
+// the field to Payload or, if it is not a user payload, to the allowlist
+// below. Only direct fields are checked; nested messages (e.g.
+// TaskFailureDetails.StackTrace) deliberately stay inline.
+func TestPayloadAccessorCompleteness(t *testing.T) {
+	t.Parallel()
+
+	// StringValue fields that are not user payloads and must stay inline.
+	nonPayloadFields := map[string]bool{
+		"version":        true, // workflow definition version, small and system-set
+		"workflowSpanID": true, // tracing correlation ID
+	}
+
+	const marker = "reflected-marker"
+
+	desc := (&protos.HistoryEvent{}).ProtoReflect().Descriptor()
+	oneof := desc.Oneofs().ByName("eventType")
+	require.NotNil(t, oneof)
+
+	fields := oneof.Fields()
+	for i := range fields.Len() {
+		variant := fields.Get(i)
+		msgDesc := variant.Message()
+		require.NotNil(t, msgDesc, "oneof variant %s is not a message", variant.Name())
+
+		subfields := msgDesc.Fields()
+		for j := range subfields.Len() {
+			sub := subfields.Get(j)
+			if sub.Kind() != protoreflect.MessageKind || sub.Message().FullName() != "google.protobuf.StringValue" {
+				continue
+			}
+			if nonPayloadFields[string(sub.Name())] {
+				continue
+			}
+
+			// Build a HistoryEvent of this variant with the field set.
+			e := &protos.HistoryEvent{}
+			er := e.ProtoReflect()
+			vmsg := er.NewField(variant).Message()
+			sv := vmsg.NewField(sub).Message()
+			sv.Set(sv.Descriptor().Fields().ByName("value"), protoreflect.ValueOfString(marker))
+			vmsg.Set(sub, protoreflect.ValueOfMessage(sv))
+			er.Set(variant, protoreflect.ValueOfMessage(vmsg))
+
+			p := Payload(e)
+			require.NotNilf(t, p,
+				"HistoryEvent variant %q has StringValue field %q that the Payload accessor does not expose; add it to Payload or to the non-payload allowlist",
+				variant.Name(), sub.Name())
+			assert.Equal(t, marker, p.GetValue())
+		}
+	}
+}

--- a/backend/payloadstore/payloadstore.go
+++ b/backend/payloadstore/payloadstore.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package payloadstore defines how large workflow history payloads are
+// offloaded to a pluggable external store, replacing the inline value
+// with a small in-band reference (see codec.go). It carries no store
+// implementation: with a nil Store the feature is a strict no-op and
+// workflow behavior is byte-identical to a build without it. A backend
+// embedder injects a Store to enable offloading, and the Payload accessor
+// is the single enumeration of payload-carrying history event fields that
+// both the offload and dereference sides share.
+package payloadstore
+
+import (
+	"context"
+	"crypto/sha256"
+)
+
+// DefaultThreshold is the payload size in bytes at or above which
+// implementations should offload a payload when no explicit threshold is
+// configured.
+const DefaultThreshold = 16 * 1024
+
+// Reference identifies a payload held in an external payload store. It is
+// what gets persisted in workflow history in place of the payload itself.
+type Reference struct {
+	// Checksum is the SHA-256 of the payload bytes. It makes the
+	// reference content-addressed and lets readers detect tampering or
+	// corruption of the stored payload.
+	Checksum [sha256.Size]byte
+	// Key is the store-assigned lookup key for the payload.
+	Key string
+	// Size is the payload length in bytes.
+	Size uint64
+}
+
+// Store persists workflow payloads outside of workflow history and owns
+// the policy for which payloads are worth offloading.
+//
+// Implementations must be safe for concurrent use. Put must be idempotent
+// for identical data: offload runs again with the same payloads when a
+// workflow turn is retried after a failed save.
+type Store interface {
+	// ShouldOffload reports whether a payload of the given size in bytes
+	// should be offloaded to this store. It is consulted on the save hot
+	// path for every new payload-bearing event, so it must be fast and
+	// deterministic. Values that already encode a Reference are never
+	// offered.
+	ShouldOffload(size int) bool
+
+	// Put stores data and returns a Reference whose Checksum is
+	// sha256(data). instanceID is the workflow instance the payload
+	// belongs to; stores may use it to partition payloads so a reference
+	// forged into one instance's history cannot address another's data.
+	Put(ctx context.Context, instanceID string, data []byte) (Reference, error)
+
+	// Get returns the payload identified by ref. instanceID is the
+	// workflow instance whose history carried the reference; stores that
+	// partition payloads by instance use it to refuse resolving a
+	// reference forged into another instance's history. Implementations
+	// MUST verify that the SHA-256 of the returned bytes equals
+	// ref.Checksum and fail on mismatch, so a tampered or corrupted store
+	// surfaces as an error rather than as silently wrong payload data.
+	Get(ctx context.Context, instanceID string, ref Reference) ([]byte, error)
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	go.opentelemetry.io/otel/exporters/zipkin v1.34.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.35.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
@@ -41,7 +42,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/main.go
+++ b/main.go
@@ -52,7 +52,11 @@ func createTaskHubWorker(server *grpc.Server, sqliteFilePath string, logger back
 		Logger:   logger,
 		AppID:    "example",
 	})
-	activityWorker := backend.NewActivityTaskWorker(be, executor, logger)
+	activityWorker := backend.NewActivityWorker(backend.ActivityWorkerOptions{
+		Backend:  be,
+		Executor: executor,
+		Logger:   logger,
+	})
 	taskHubWorker := backend.NewTaskHubWorker(be, workflowWorker, activityWorker, logger)
 	return taskHubWorker
 }

--- a/samples/distributedtracing/distributedtracing.go
+++ b/samples/distributedtracing/distributedtracing.go
@@ -81,7 +81,11 @@ func Init(ctx context.Context, r *task.TaskRegistry) (backend.TaskHubClient, bac
 		Executor: executor,
 		Logger:   logger,
 	})
-	activityWorker := backend.NewActivityTaskWorker(be, executor, logger)
+	activityWorker := backend.NewActivityWorker(backend.ActivityWorkerOptions{
+		Backend:  be,
+		Executor: executor,
+		Logger:   logger,
+	})
 	taskHubWorker := backend.NewTaskHubWorker(be, workflowWorker, activityWorker, logger)
 
 	// Start the worker

--- a/samples/externalevents/externalevents.go
+++ b/samples/externalevents/externalevents.go
@@ -72,7 +72,11 @@ func Init(ctx context.Context, r *task.TaskRegistry) (backend.TaskHubClient, bac
 		Executor: executor,
 		Logger:   logger,
 	})
-	activityWorker := backend.NewActivityTaskWorker(be, executor, logger)
+	activityWorker := backend.NewActivityWorker(backend.ActivityWorkerOptions{
+		Backend:  be,
+		Executor: executor,
+		Logger:   logger,
+	})
 	taskHubWorker := backend.NewTaskHubWorker(be, workflowWorker, activityWorker, logger)
 
 	// Start the worker

--- a/samples/parallel/parallel.go
+++ b/samples/parallel/parallel.go
@@ -64,7 +64,11 @@ func Init(ctx context.Context, r *task.TaskRegistry) (backend.TaskHubClient, bac
 		Executor: executor,
 		Logger:   logger,
 	})
-	activityWorker := backend.NewActivityTaskWorker(be, executor, logger)
+	activityWorker := backend.NewActivityWorker(backend.ActivityWorkerOptions{
+		Backend:  be,
+		Executor: executor,
+		Logger:   logger,
+	})
 	taskHubWorker := backend.NewTaskHubWorker(be, workflowWorker, activityWorker, logger)
 
 	// Start the worker

--- a/samples/retries/retries.go
+++ b/samples/retries/retries.go
@@ -62,7 +62,11 @@ func Init(ctx context.Context, r *task.TaskRegistry) (backend.TaskHubClient, bac
 		Executor: executor,
 		Logger:   logger,
 	})
-	activityWorker := backend.NewActivityTaskWorker(be, executor, logger)
+	activityWorker := backend.NewActivityWorker(backend.ActivityWorkerOptions{
+		Backend:  be,
+		Executor: executor,
+		Logger:   logger,
+	})
 	taskHubWorker := backend.NewTaskHubWorker(be, workflowWorker, activityWorker, logger)
 
 	// Start the worker

--- a/samples/sequence/sequence.go
+++ b/samples/sequence/sequence.go
@@ -60,7 +60,11 @@ func Init(ctx context.Context, r *task.TaskRegistry) (backend.TaskHubClient, bac
 		Executor: executor,
 		Logger:   logger,
 	})
-	activityWorker := backend.NewActivityTaskWorker(be, executor, logger)
+	activityWorker := backend.NewActivityWorker(backend.ActivityWorkerOptions{
+		Backend:  be,
+		Executor: executor,
+		Logger:   logger,
+	})
 	taskHubWorker := backend.NewTaskHubWorker(be, workflowWorker, activityWorker, logger)
 
 	// Start the worker

--- a/samples/taskexecutionid/taskexecutionid.go
+++ b/samples/taskexecutionid/taskexecutionid.go
@@ -66,7 +66,11 @@ func Init(ctx context.Context, r *task.TaskRegistry) (backend.TaskHubClient, bac
 		Executor: executor,
 		Logger:   logger,
 	})
-	activityWorker := backend.NewActivityTaskWorker(be, executor, logger)
+	activityWorker := backend.NewActivityWorker(backend.ActivityWorkerOptions{
+		Backend:  be,
+		Executor: executor,
+		Logger:   logger,
+	})
 	taskHubWorker := backend.NewTaskHubWorker(be, workflowWorker, activityWorker, logger)
 
 	// Start the worker

--- a/tests/grpc/grpc_test.go
+++ b/tests/grpc/grpc_test.go
@@ -49,7 +49,11 @@ func TestMain(m *testing.M) {
 		AppID:    "testapp",
 	})
 
-	activityWorker := backend.NewActivityTaskWorker(be, grpcExecutor, logger)
+	activityWorker := backend.NewActivityWorker(backend.ActivityWorkerOptions{
+		Backend:  be,
+		Executor: grpcExecutor,
+		Logger:   logger,
+	})
 	taskHubWorker := backend.NewTaskHubWorker(be, workflowWorker, activityWorker, logger)
 	if err := taskHubWorker.Start(ctx); err != nil {
 		log.Fatalf("failed to start worker: %v", err)

--- a/tests/orchestrations_test.go
+++ b/tests/orchestrations_test.go
@@ -2030,7 +2030,6 @@ func Test_StartedAt_AfterExecution(t *testing.T) {
 		"StartedAt %v should be >= CreatedAt %v", startedAt, metadata.CreatedAt.AsTime())
 }
 
-
 func Test_StartedAt_WithScheduleTime(t *testing.T) {
 	r := task.NewTaskRegistry()
 	r.AddWorkflowN("StartedAtAfterExec", func(ctx *task.WorkflowContext) (any, error) {
@@ -2135,7 +2134,11 @@ func initTaskHubWorker(ctx context.Context, r *task.TaskRegistry, opts ...backen
 		Logger:   logger,
 		AppID:    "testapp",
 	}, opts...)
-	activityWorker := backend.NewActivityTaskWorker(be, executor, logger, opts...)
+	activityWorker := backend.NewActivityWorker(backend.ActivityWorkerOptions{
+		Backend:  be,
+		Executor: executor,
+		Logger:   logger,
+	}, opts...)
 	taskHubWorker := backend.NewTaskHubWorker(be, workflowWorker, activityWorker, logger)
 	if err := taskHubWorker.Start(ctx); err != nil {
 		panic(err)


### PR DESCRIPTION
Adds `backend/payloadstore`: a pluggable contract for offloading large workflow event payloads out of history into an external store, persisted as small content-addressed references, plus the engine-side hooks that resolve those references back to full payloads before anything reaches user code. **No store implementation ships and nothing activates without one**: every hook is a strict no-op when no store is injected

## Breaking change

`NewActivityTaskWorker` and `NewActivityTaskWorkerWithInProcess` are removed in favor of `NewActivityWorker(ActivityWorkerOptions)`, matching `NewWorkflowWorker`. All in-repo call sites (samples, tests, `main.go`) are migrated. Should only affect dapr.