### PR TITLE
[0.12] fix: reset ParentTraceContext on ContinueAsNew to bound per-generation traces (#113)

### DIFF
--- a/api/helpers/tracing.go
+++ b/api/helpers/tracing.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/hex"
 	"reflect"
 	"strings"
@@ -210,6 +211,26 @@ func TraceContextFromSpan(span trace.Span) *protos.TraceContext {
 		}
 	}
 	return tc
+}
+
+// NewRootTraceContext returns a fresh W3C TraceContext with a randomly
+// generated trace ID and span ID and the sampled flag set. It is intended
+// for cases where a new root trace should be started explicitly, such as
+// each generation of a ContinueAsNew workflow (dapr/dapr#10064): copying
+// the previous generation's ParentTraceContext caused every generation to
+// re-parent off the original trace and produced unbounded traces.
+func NewRootTraceContext() *protos.TraceContext {
+	var traceID trace.TraceID
+	var spanID trace.SpanID
+	if _, err := rand.Read(traceID[:]); err != nil {
+		return nil
+	}
+	if _, err := rand.Read(spanID[:]); err != nil {
+		return nil
+	}
+	return &protos.TraceContext{
+		TraceParent: "00-" + traceID.String() + "-" + spanID.String() + "-01",
+	}
 }
 
 func ChangeSpanID(span trace.Span, newSpanID trace.SpanID) {

--- a/backend/runtimestate/applier.go
+++ b/backend/runtimestate/applier.go
@@ -96,7 +96,20 @@ func (a *Applier) Actions(s *protos.WorkflowRuntimeState, customStatus *wrappers
 					Router: action.Router,
 				})
 
-				// Duplicate the start event info, updating just the input
+				// Duplicate the start event info, updating just the input.
+				// ParentTraceContext is reset to a fresh root when the prior
+				// generation was traced. Copying the previous generation's
+				// ParentTraceContext caused every generation of an eternal
+				// ContinueAsNew workflow to re-parent its span off the very
+				// first generation's trace and produce an unbounded single
+				// trace that kept accumulating spans across every iteration
+				// (dapr/dapr#10064). If the workflow was not being traced
+				// (prior ParentTraceContext was nil), leave it nil so we do
+				// not introduce tracing where the caller opted out.
+				var newParentTraceContext *protos.TraceContext
+				if s.StartEvent.ParentTraceContext != nil {
+					newParentTraceContext = helpers.NewRootTraceContext()
+				}
 				_ = AddEvent(newState,
 					&protos.HistoryEvent{
 						EventId:   -1,
@@ -110,7 +123,7 @@ func (a *Applier) Actions(s *protos.WorkflowRuntimeState, customStatus *wrappers
 									InstanceId:  s.InstanceId,
 									ExecutionId: wrapperspb.String(uuid.New().String()),
 								},
-								ParentTraceContext: s.StartEvent.ParentTraceContext,
+								ParentTraceContext: newParentTraceContext,
 							},
 						},
 						Router: action.Router,

--- a/tests/runtimestate_test.go
+++ b/tests/runtimestate_test.go
@@ -254,6 +254,86 @@ func Test_RuntimeState_ContinueAsNew(t *testing.T) {
 	}
 }
 
+// Test_RuntimeState_ContinueAsNew_ResetsParentTraceContext asserts that a
+// ContinueAsNew transition resets the ParentTraceContext to a fresh root when
+// the prior generation was traced, and leaves it nil when it was not. Copying
+// the previous generation's ParentTraceContext caused every generation of an
+// eternal ContinueAsNew workflow to re-parent its span off the first
+// generation's trace, producing an unbounded single trace (dapr/dapr#10064).
+func Test_RuntimeState_ContinueAsNew_ResetsParentTraceContext(t *testing.T) {
+	const iid = "abc"
+	const expectedName = "MyWorkflow"
+	const priorTraceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+	buildState := func(ptc *protos.TraceContext) *protos.WorkflowRuntimeState {
+		return runtimestate.NewWorkflowRuntimeState(iid, nil, []*protos.HistoryEvent{
+			{
+				EventId:   -1,
+				Timestamp: timestamppb.New(time.Now()),
+				EventType: &protos.HistoryEvent_ExecutionStarted{
+					ExecutionStarted: &protos.ExecutionStartedEvent{
+						Name: expectedName,
+						WorkflowInstance: &protos.WorkflowInstance{
+							InstanceId:  iid,
+							ExecutionId: wrapperspb.String(uuid.New().String()),
+						},
+						ParentTraceContext: ptc,
+					},
+				},
+			},
+		})
+	}
+
+	canActions := []*protos.WorkflowAction{
+		{
+			Id: 1,
+			WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+				CompleteWorkflow: &protos.CompleteWorkflowAction{
+					WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW,
+					Result:         wrapperspb.String("\"round-2\""),
+				},
+			},
+		},
+	}
+
+	t.Run("prior generation was traced -> fresh root trace context", func(t *testing.T) {
+		state := buildState(&protos.TraceContext{
+			TraceParent: priorTraceParent,
+			TraceState:  wrapperspb.String("vendor=value"),
+		})
+
+		applier := runtimestate.NewApplier("example", "")
+		result, err := applier.Actions(state, nil, canActions, nil, nil)
+		require.NoError(t, err)
+		require.True(t, result.ContinuedAsNew)
+		require.Len(t, state.NewEvents, 2)
+
+		ec := state.NewEvents[1].GetExecutionStarted()
+		require.NotNil(t, ec)
+		require.NotNil(t, ec.ParentTraceContext,
+			"a traced workflow must keep tracing across ContinueAsNew, just rooted fresh")
+		assert.NotEqual(t, priorTraceParent, ec.ParentTraceContext.GetTraceParent(),
+			"new generation must start a fresh root trace, not inherit the previous generation's TraceParent")
+		assert.Nil(t, ec.ParentTraceContext.GetTraceState(),
+			"prior TraceState must not be carried over into the fresh root")
+	})
+
+	t.Run("prior generation was not traced -> new generation stays untraced", func(t *testing.T) {
+		state := buildState(nil)
+
+		applier := runtimestate.NewApplier("example", "")
+		result, err := applier.Actions(state, nil, canActions, nil, nil)
+		require.NoError(t, err)
+		require.True(t, result.ContinuedAsNew)
+		require.Len(t, state.NewEvents, 2)
+
+		ec := state.NewEvents[1].GetExecutionStarted()
+		require.NotNil(t, ec)
+		assert.Nil(t, ec.ParentTraceContext,
+			"a workflow that opted out of tracing must not be opted in by ContinueAsNew")
+	})
+}
+
 func Test_CreateTimer(t *testing.T) {
 	const iid = "abc"
 	timerName := "foo"


### PR DESCRIPTION
Every generation of a ContinueAsNew workflow copied the previous generation's ParentTraceContext from the ExecutionStartedEvent verbatim, so each generation re-parented its span off the very first generation's trace. A long-running eternal orchestration therefore produced a single unbounded trace that kept accumulating spans across every iteration.

Reset the field on the new-generation ExecutionStartedEvent instead. If the prior generation was traced, mint a fresh W3C root TraceContext (new random trace and span IDs, sampled flag on, no carried-over TraceState). If the prior generation was not traced, leave the field nil so a caller that opted out of tracing is not opted back in by the CAN transition.

Ref: dapr/dapr#10064
Backport: https://github.com/dapr/durabletask-go/pull/113