### PR TITLE
executor: buffer the work-item dispatch channels

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -110,7 +110,15 @@ func WithSkipWaitForInstanceStart() grpcExecutorOptions {
 
 func NewGrpcExecutor(be Backend, logger Logger, opts ...grpcExecutorOptions) (executor Executor, registerServerFn func(grpcServer grpc.ServiceRegistrar)) {
 	grpcExecutor := &grpcExecutor{
-		workItemQueue:     make(chan *protos.WorkItem),
+		// Buffered: a turn dispatch must not rendezvous with a stream's
+		// synchronous send loop. Unbuffered, every producer (holding its
+		// actor turn upstream) parked until some stream finished its
+		// in-flight delta rewrite plus gRPC send, capping cluster turn
+		// dispatch at the streams' aggregate send rate and convoying
+		// thousands of goroutines at high load. Items resting in the
+		// buffer across a total stream outage are recovered by the same
+		// turn-timeout retry path that covers a mid-send disconnect.
+		workItemQueue:     make(chan *protos.WorkItem, 512),
 		backend:           be,
 		logger:            logger,
 		pendingWorkflows:  &sync.Map{},

--- a/backend/executor_stateful.go
+++ b/backend/executor_stateful.go
@@ -20,9 +20,11 @@ type streamState struct {
 	// rendezvous (HRW) affinity hashing.
 	id string
 
-	// ch delivers work items routed to this specific stream by instance affinity.
-	// Unbuffered: a routed item is taken only when this stream's dispatch loop is
-	// ready, otherwise the producer falls back to the shared queue (any stream).
+	// ch delivers work items routed to this specific stream by instance
+	// affinity. Small buffer (see newStreamState): a routed item is taken
+	// when the stream's dispatch loop is ready or queued briefly while it
+	// is mid-send; the producer falls back to the shared queue (any
+	// stream) when the buffer is full.
 	ch chan *protos.WorkItem
 
 	// statefulHistory is true if the worker advertised
@@ -42,8 +44,16 @@ type streamState struct {
 
 func newStreamState(id string, req *protos.GetWorkItemsRequest) *streamState {
 	s := &streamState{
-		id:      id,
-		ch:      make(chan *protos.WorkItem),
+		id: id,
+		// Small buffer: the affinity fast path can queue a few turns for
+		// the warm owner while it is mid-send, keeping the delta
+		// optimization instead of spilling to the shared queue (full
+		// history resend) whenever the owner is briefly busy. The
+		// overflow fallback to the shared queue is unchanged, so a slow
+		// owner still never stalls an instance. Undelivered items in a
+		// dying stream's buffer recover via the turn-timeout retry path,
+		// the same class as a mid-send disconnect.
+		ch:      make(chan *protos.WorkItem, 8),
 		warm:    make(map[api.InstanceID]int),
 		maxWarm: maxWarmInstancesPerStream,
 	}


### PR DESCRIPTION
The shared work-item queue and the per-stream affinity channel were both unbuffered, so every turn dispatch rendezvoused with a stream's synchronous send loop (delta rewrite plus gRPC send).

 A 512 buffer on the shared queue decouples producers from send latency;
 an 8 buffer on the affinity channel keeps briefly-busy warm owners on
 the delta path instead of spilling to full-history resends. Overflow
 and fallback semantics are unchanged; items resting in a buffer across
 a stream death recover through the same turn-timeout retry class as a
 mid-send disconnect.