### PR TITLE
executor: populate WorkflowRequest.ExecutionId from the run's ExecutionStarted event

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -128,12 +128,31 @@ func NewGrpcExecutor(be Backend, logger Logger, opts ...grpcExecutorOptions) (ex
 }
 
 // ExecuteWorkflow implements Executor
+// executionID returns the execution ID of the run these events belong to,
+// taken from the ExecutionStarted event. New events are scanned first so a
+// recreated or continued-as-new run reports its own execution rather than a
+// stale one. SDKs use this to discriminate schedulings across executions of
+// the same instance ID (e.g. the .NET SDK seeds its deterministic
+// TaskExecutionId derivation with it); without it, SDKs that derive
+// deterministically fall back to the instance ID as the seed, and two
+// executions of a recreated instance produce colliding TaskExecutionIds.
+func executionID(oldEvents, newEvents []*protos.HistoryEvent) *wrapperspb.StringValue {
+	for _, events := range [2][]*protos.HistoryEvent{newEvents, oldEvents} {
+		for _, e := range events {
+			if id := e.GetExecutionStarted().GetWorkflowInstance().GetExecutionId(); id != nil {
+				return id
+			}
+		}
+	}
+	return nil
+}
+
 func (executor *grpcExecutor) ExecuteWorkflow(ctx context.Context, iid api.InstanceID, oldEvents []*protos.HistoryEvent, newEvents []*protos.HistoryEvent, opts ExecuteOptions) (*protos.WorkflowResponse, error) {
 	executor.pendingWorkflows.Store(iid, &pendingWorkflow{instanceID: iid})
 
 	req := &protos.WorkflowRequest{
 		InstanceId:        string(iid),
-		ExecutionId:       nil,
+		ExecutionId:       executionID(oldEvents, newEvents),
 		PastEvents:        oldEvents,
 		NewEvents:         newEvents,
 		PropagatedHistory: opts.PropagatedHistory,

--- a/backend/executor_executionid_test.go
+++ b/backend/executor_executionid_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+func executionStarted(execID string) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name: "test",
+				WorkflowInstance: &protos.WorkflowInstance{
+					InstanceId:  "instance",
+					ExecutionId: wrapperspb.String(execID),
+				},
+			},
+		},
+	}
+}
+
+func Test_executionID(t *testing.T) {
+	t.Parallel()
+
+	other := &protos.HistoryEvent{
+		EventType: &protos.HistoryEvent_TaskScheduled{
+			TaskScheduled: &protos.TaskScheduledEvent{Name: "act"},
+		},
+	}
+
+	t.Run("from past events", func(t *testing.T) {
+		t.Parallel()
+		got := executionID([]*protos.HistoryEvent{executionStarted("exec-1"), other}, []*protos.HistoryEvent{other})
+		assert.Equal(t, "exec-1", got.GetValue())
+	})
+
+	t.Run("from new events", func(t *testing.T) {
+		t.Parallel()
+		got := executionID(nil, []*protos.HistoryEvent{executionStarted("exec-2")})
+		assert.Equal(t, "exec-2", got.GetValue())
+	})
+
+	t.Run("new events win over past so a recreated run reports its own execution", func(t *testing.T) {
+		t.Parallel()
+		got := executionID(
+			[]*protos.HistoryEvent{executionStarted("exec-old")},
+			[]*protos.HistoryEvent{executionStarted("exec-new")},
+		)
+		assert.Equal(t, "exec-new", got.GetValue())
+	})
+
+	t.Run("no execution started", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, executionID([]*protos.HistoryEvent{other}, []*protos.HistoryEvent{other}))
+	})
+
+	t.Run("execution started without an execution id", func(t *testing.T) {
+		t.Parallel()
+		e := executionStarted("ignored")
+		e.GetExecutionStarted().GetWorkflowInstance().ExecutionId = nil
+		assert.Nil(t, executionID(nil, []*protos.HistoryEvent{e}))
+	})
+}


### PR DESCRIPTION
ExecuteWorkflow has always sent ExecutionId as nil in the app-facing WorkflowRequest, even though every execution has a runtime-minted ID in its ExecutionStarted event. SDKs that derive deterministic per-task identifiers use this field as their per-execution seed; when it is absent they fall back to the instance ID, so two executions of a recreated instance ID derive colliding TaskExecutionIds. The runtime's activity de-duplication then treats the recreated execution's first activity as a redelivery of the previous execution's completed one, acks it without dispatching, and the workflow is stuck in Running forever (observed in production behind create-if-completed child workflow recreation).

Fill the field from the ExecutionStarted event, scanning new events before past events so a recreated or continued-as-new run reports its own execution rather than a stale one. Nothing server-side reads the field (all completion waits key on the instance ID alone) and the Go SDK worker ignores it, so the only observable change is that SDK workers now receive the execution ID they were designed to consume.