### PR TITLE
perf: event-driven work item completion, drop per-item waiter goroutine

### DIFF
--- a/backend/activity.go
+++ b/backend/activity.go
@@ -24,6 +24,13 @@ type ActivityExecutor interface {
 	ExecuteActivity(ctx context.Context, iid api.InstanceID, e *protos.HistoryEvent, opts ExecuteOptions) (*protos.HistoryEvent, error)
 }
 
+// asyncActivityExecutor is implemented by executors that can deliver the
+// activity result through a callback instead of blocking in ExecuteActivity.
+type asyncActivityExecutor interface {
+	canExecuteAsync() bool
+	executeActivityAsync(ctx context.Context, iid api.InstanceID, e *protos.HistoryEvent, opts ExecuteOptions, done func(*protos.HistoryEvent, error))
+}
+
 // NewActivityTaskWorker constructs an activity worker.
 func NewActivityTaskWorker(be Backend, executor ActivityExecutor, logger Logger, opts ...NewTaskWorkerOptions) TaskWorker[*ActivityWorkItem] {
 	processor := newActivityProcessor(be, executor, nil, "")
@@ -99,6 +106,57 @@ func (p *activityProcessor) ProcessWorkItem(ctx context.Context, awi *ActivityWo
 	}
 	awi.Result = result
 	return nil
+}
+
+// ProcessWorkItemAsync implements AsyncTaskProcessor. It mirrors
+// ProcessWorkItem, with the post-execution work registered as a callback run
+// by the goroutine that delivers the activity result, so no goroutine waits
+// out the app roundtrip.
+func (p *activityProcessor) ProcessWorkItemAsync(ctx context.Context, awi *ActivityWorkItem, done func(error)) bool {
+	ts := awi.NewEvent.GetTaskScheduled()
+
+	executor := p.executor
+	if p.inProcessExecutor != nil && p.inProcessNamePrefix != "" && strings.HasPrefix(ts.GetName(), p.inProcessNamePrefix) {
+		executor = p.inProcessExecutor
+	}
+	asyncExecutor, ok := executor.(asyncActivityExecutor)
+	if !ok || !asyncExecutor.canExecuteAsync() {
+		return false
+	}
+
+	if ts == nil {
+		done(fmt.Errorf("%v: invalid TaskScheduled event", awi.InstanceID))
+		return true
+	}
+	ctx, err := helpers.ContextFromTraceContext(ctx, ts.ParentTraceContext)
+	if err != nil {
+		done(fmt.Errorf("%v: failed to parse activity trace context: %w", awi.InstanceID, err))
+		return true
+	}
+	var span trace.Span
+	ctx, span = helpers.StartNewActivitySpan(ctx, ts.Name, ts.Version.GetValue(), string(awi.InstanceID), awi.NewEvent.EventId)
+
+	// set the parent trace context to be the newly created activity span
+	ts.ParentTraceContext = helpers.TraceContextFromSpan(span)
+
+	execOpts := ExecuteOptions{PropagatedHistory: awi.IncomingHistory}
+
+	asyncExecutor.executeActivityAsync(ctx, awi.InstanceID, awi.NewEvent, execOpts, func(result *protos.HistoryEvent, err error) {
+		if span != nil {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}
+		if err != nil {
+			done(err)
+			return
+		}
+		awi.Result = result
+		done(nil)
+	})
+	return true
 }
 
 // CompleteWorkItem implements TaskDispatcher

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -167,6 +167,21 @@ type Backend interface {
 	GetInstanceHistory(ctx context.Context, req *protos.GetInstanceHistoryRequest) (*protos.GetInstanceHistoryResponse, error)
 }
 
+// CompletionCallbackBackend is an optional interface a Backend can implement
+// to deliver task completions through a registered callback instead of waking
+// a goroutine blocked in WaitForWorkflowTaskCompletion or
+// WaitForActivityCompletion. The callback is invoked exactly once, on the
+// goroutine that delivers the completion or cancellation, with the response,
+// or with [api.ErrTaskCancelled] if the task was cancelled. Registration
+// replaces any pending wait or callback for the same task. The returned
+// deregister function removes the registration; calling it after delivery, or
+// more than once, is a no-op.
+type CompletionCallbackBackend interface {
+	OnWorkflowTaskCompletion(*protos.WorkflowRequest, func(*protos.WorkflowResponse, error)) func()
+
+	OnActivityCompletion(*protos.ActivityRequest, func(*protos.ActivityResponse, error)) func()
+}
+
 // MarshalHistoryEvent serializes the [HistoryEvent] into a protobuf byte array.
 func MarshalHistoryEvent(e *HistoryEvent) ([]byte, error) {
 	if bytes, err := proto.Marshal(e); err != nil {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -176,6 +176,13 @@ type Backend interface {
 // replaces any pending wait or callback for the same task. The returned
 // deregister function removes the registration; calling it after delivery, or
 // more than once, is a no-op.
+// CompletionCallbackBackend registers completion callbacks for dispatched
+// work items. Contract: a registration is removed ONLY by the returned
+// deregister closure, never by delivering to the callback. The executor
+// discards stale-token deliveries and keeps waiting on the same
+// registration, so an implementation that consumes the registration on
+// delivery opens a window where the genuine response arrives unroutable and
+// the waiter strands forever.
 type CompletionCallbackBackend interface {
 	OnWorkflowTaskCompletion(*protos.WorkflowRequest, func(*protos.WorkflowResponse, error)) func()
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -170,19 +170,19 @@ type Backend interface {
 // CompletionCallbackBackend is an optional interface a Backend can implement
 // to deliver task completions through a registered callback instead of waking
 // a goroutine blocked in WaitForWorkflowTaskCompletion or
-// WaitForActivityCompletion. The callback is invoked exactly once, on the
-// goroutine that delivers the completion or cancellation, with the response,
-// or with [api.ErrTaskCancelled] if the task was cancelled. Registration
-// replaces any pending wait or callback for the same task. The returned
-// deregister function removes the registration; calling it after delivery, or
-// more than once, is a no-op.
-// CompletionCallbackBackend registers completion callbacks for dispatched
-// work items. Contract: a registration is removed ONLY by the returned
-// deregister closure, never by delivering to the callback. The executor
-// discards stale-token deliveries and keeps waiting on the same
-// registration, so an implementation that consumes the registration on
-// delivery opens a window where the genuine response arrives unroutable and
-// the waiter strands forever.
+// WaitForActivityCompletion. The callback runs on the goroutine that delivers
+// the completion or cancellation, with the response, or with
+// [api.ErrTaskCancelled] if the task was cancelled. Registering replaces any
+// pending wait or callback for the same task.
+//
+// A registration is removed ONLY by the returned deregister closure, never by
+// delivering to the callback: the executor discards stale-token deliveries
+// and keeps waiting on the same registration, so an implementation that
+// consumed the registration on delivery would open a window where the
+// genuine response arrives unroutable and the waiter strands forever. The
+// callback may therefore be invoked more than once (stale deliveries
+// included); the executor's arbiter settles exactly one. Calling the
+// deregister closure after delivery, or more than once, is a no-op.
 type CompletionCallbackBackend interface {
 	OnWorkflowTaskCompletion(*protos.WorkflowRequest, func(*protos.WorkflowResponse, error)) func()
 

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -208,7 +208,11 @@ func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.Instanc
 		return
 	}
 
-	g.pendingWorkflows.Store(iid, &pendingWorkflow{instanceID: iid})
+	// Capture the tracked value: a superseded attempt settling late must not
+	// delete a newer attempt's entry (both share the instance key), or the
+	// newer dispatch loses stream-disconnect/shutdown cancellation.
+	trackedWorkflow := &pendingWorkflow{instanceID: iid}
+	g.pendingWorkflows.Store(iid, trackedWorkflow)
 
 	req := &protos.WorkflowRequest{
 		InstanceId:        string(iid),
@@ -246,7 +250,7 @@ func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.Instanc
 		if !wait.settle() {
 			return
 		}
-		g.pendingWorkflows.Delete(iid)
+		g.pendingWorkflows.CompareAndDelete(iid, trackedWorkflow)
 		if err != nil {
 			if errors.Is(err, api.ErrTaskCancelled) {
 				done(nil, errors.New("operation aborted"))
@@ -280,7 +284,10 @@ func (g *grpcExecutor) executeActivityAsync(ctx context.Context, iid api.Instanc
 	}
 
 	key := GetActivityExecutionKey(string(iid), e.EventId)
-	g.pendingActivities.Store(key, &pendingActivity{instanceID: iid, taskID: e.EventId})
+	// See executeWorkflowAsync: CompareAndDelete-able so a late-settling
+	// superseded attempt cannot evict a newer attempt's tracking entry.
+	trackedActivity := &pendingActivity{instanceID: iid, taskID: e.EventId}
+	g.pendingActivities.Store(key, trackedActivity)
 
 	task := e.GetTaskScheduled()
 	req := &protos.ActivityRequest{
@@ -314,7 +321,7 @@ func (g *grpcExecutor) executeActivityAsync(ctx context.Context, iid api.Instanc
 		if !wait.settle() {
 			return
 		}
-		g.pendingActivities.Delete(key)
+		g.pendingActivities.CompareAndDelete(key, trackedActivity)
 		if err != nil {
 			if errors.Is(err, api.ErrTaskCancelled) {
 				done(nil, errors.New("operation aborted"))
@@ -342,7 +349,8 @@ func (g *grpcExecutor) executeActivityAsync(ctx context.Context, iid api.Instanc
 
 // ExecuteWorkflow implements Executor
 func (executor *grpcExecutor) ExecuteWorkflow(ctx context.Context, iid api.InstanceID, oldEvents []*protos.HistoryEvent, newEvents []*protos.HistoryEvent, opts ExecuteOptions) (*protos.WorkflowResponse, error) {
-	executor.pendingWorkflows.Store(iid, &pendingWorkflow{instanceID: iid})
+	trackedWorkflow := &pendingWorkflow{instanceID: iid}
+	executor.pendingWorkflows.Store(iid, trackedWorkflow)
 
 	req := &protos.WorkflowRequest{
 		InstanceId:        string(iid),
@@ -375,8 +383,9 @@ func (executor *grpcExecutor) ExecuteWorkflow(ctx context.Context, iid api.Insta
 
 	resp, err := wait(ctx)
 
-	// this workflow is either completed or cancelled, but its no longer pending, delete it
-	executor.pendingWorkflows.Delete(iid)
+	// This workflow is completed or cancelled and no longer pending. Remove
+	// only our own entry: a newer attempt may have re-stored the key.
+	executor.pendingWorkflows.CompareAndDelete(iid, trackedWorkflow)
 	if err != nil {
 		if errors.Is(err, api.ErrTaskCancelled) {
 			return nil, errors.New("operation aborted")
@@ -391,7 +400,8 @@ func (executor *grpcExecutor) ExecuteWorkflow(ctx context.Context, iid api.Insta
 // ExecuteActivity implements Executor
 func (executor *grpcExecutor) ExecuteActivity(ctx context.Context, iid api.InstanceID, e *protos.HistoryEvent, opts ExecuteOptions) (*protos.HistoryEvent, error) {
 	key := GetActivityExecutionKey(string(iid), e.EventId)
-	executor.pendingActivities.Store(key, &pendingActivity{instanceID: iid, taskID: e.EventId})
+	trackedActivity := &pendingActivity{instanceID: iid, taskID: e.EventId}
+	executor.pendingActivities.Store(key, trackedActivity)
 
 	task := e.GetTaskScheduled()
 
@@ -427,8 +437,9 @@ func (executor *grpcExecutor) ExecuteActivity(ctx context.Context, iid api.Insta
 
 	resp, err := wait(ctx)
 
-	// this activity is either completed or cancelled, but its no longer pending, delete it
-	executor.pendingActivities.Delete(key)
+	// This activity is completed or cancelled and no longer pending. Remove
+	// only our own entry: a newer attempt may have re-stored the key.
+	executor.pendingActivities.CompareAndDelete(key, trackedActivity)
 	if err != nil {
 		if errors.Is(err, api.ErrTaskCancelled) {
 			return nil, errors.New("operation aborted")
@@ -543,7 +554,9 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 				if err != nil {
 					g.logger.Warnf("failed to cancel activity task: %v", err)
 				}
-				g.pendingActivities.Delete(key)
+				// Only this stream's entry: a newer attempt from a fresh
+				// stream may have re-stored the key since the Range yielded.
+				g.pendingActivities.CompareAndDelete(key, value)
 			}
 			return true
 		})

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -135,6 +135,211 @@ func NewGrpcExecutor(be Backend, logger Logger, opts ...grpcExecutorOptions) (ex
 	}
 }
 
+// asyncWait arbitrates the single delivery of an asynchronously executed work
+// item's result between the backend completion callback, the context watcher,
+// and a dispatch failure. Whichever fires first wins; it also stops the
+// context watcher and deregisters the backend callback.
+type asyncWait struct {
+	mu    sync.Mutex
+	fired bool
+	stop  func() bool
+	dereg func()
+}
+
+func (a *asyncWait) setStop(stop func() bool) {
+	a.mu.Lock()
+	if a.fired {
+		a.mu.Unlock()
+		stop()
+		return
+	}
+	a.stop = stop
+	a.mu.Unlock()
+}
+
+func (a *asyncWait) setDeregister(dereg func()) {
+	a.mu.Lock()
+	if a.fired {
+		a.mu.Unlock()
+		dereg()
+		return
+	}
+	a.dereg = dereg
+	a.mu.Unlock()
+}
+
+// settle reports whether the caller won the race to deliver the result.
+func (a *asyncWait) settle() bool {
+	a.mu.Lock()
+	if a.fired {
+		a.mu.Unlock()
+		return false
+	}
+	a.fired = true
+	stop, dereg := a.stop, a.dereg
+	a.mu.Unlock()
+	if stop != nil {
+		stop()
+	}
+	if dereg != nil {
+		dereg()
+	}
+	return true
+}
+
+// canExecuteAsync reports whether the backend can deliver completions by
+// callback, which is what the executeWorkflowAsync and executeActivityAsync
+// paths need.
+func (g *grpcExecutor) canExecuteAsync() bool {
+	_, ok := g.backend.(CompletionCallbackBackend)
+	return ok
+}
+
+// executeWorkflowAsync is the event-driven form of ExecuteWorkflow. Instead of
+// blocking until the workflow task completes, it registers done with the
+// backend and returns once the work item is dispatched; done is invoked
+// exactly once, with the same result ExecuteWorkflow would have returned, on
+// the goroutine that delivers the completion, the cancellation, the context
+// error, or the dispatch failure.
+func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.InstanceID, oldEvents []*protos.HistoryEvent, newEvents []*protos.HistoryEvent, opts ExecuteOptions, done func(*protos.WorkflowResponse, error)) {
+	cbBackend, ok := g.backend.(CompletionCallbackBackend)
+	if !ok {
+		done(nil, errors.New("backend does not support completion callbacks"))
+		return
+	}
+
+	g.pendingWorkflows.Store(iid, &pendingWorkflow{instanceID: iid})
+
+	req := &protos.WorkflowRequest{
+		InstanceId:        string(iid),
+		ExecutionId:       nil,
+		PastEvents:        oldEvents,
+		NewEvents:         newEvents,
+		PropagatedHistory: opts.PropagatedHistory,
+	}
+	// The token correlates this dispatch with its response. A completion
+	// echoing a different token belongs to a superseded dispatch of the same
+	// instance (a duplicate forward delivery, or a response parked by an
+	// aborted attempt): adopting it would commit a turn computed from older
+	// history and strand the instance (the chaos-campaign janitor-livelock
+	// class). Workers that do not echo tokens send an empty one and keep
+	// today's behavior.
+	token := uuid.NewString()
+	workItem := &protos.WorkItem{
+		Request: &protos.WorkItem_WorkflowRequest{
+			WorkflowRequest: req,
+		},
+		CompletionToken: token,
+	}
+
+	wait := &asyncWait{}
+	var deliver func(resp *protos.WorkflowResponse, err error)
+	deliver = func(resp *protos.WorkflowResponse, err error) {
+		if err == nil && resp.GetCompletionToken() != "" && resp.GetCompletionToken() != token {
+			g.logger.Warnf("%s: discarding stale workflow task response (completion token mismatch); waiting for the current dispatch's response", iid)
+			// Re-register for the real response; registration drains any
+			// parked payload so a response displaced by the stale one is
+			// re-arbitrated rather than stranding on the executor actor.
+			wait.setDeregister(cbBackend.OnWorkflowTaskCompletion(req, deliver))
+			return
+		}
+		if !wait.settle() {
+			return
+		}
+		g.pendingWorkflows.Delete(iid)
+		if err != nil {
+			if errors.Is(err, api.ErrTaskCancelled) {
+				done(nil, errors.New("operation aborted"))
+				return
+			}
+			g.logger.Warnf("%s: failed before receiving workflow result", iid)
+			done(nil, err)
+			return
+		}
+		done(resp, nil)
+	}
+
+	wait.setDeregister(cbBackend.OnWorkflowTaskCompletion(req, deliver))
+	wait.setStop(context.AfterFunc(ctx, func() {
+		deliver(nil, ctx.Err())
+	}))
+
+	if err := g.dispatchWorkflowWorkItem(ctx, iid, workItem); err != nil {
+		g.logger.Warnf("%s: context canceled before dispatching workflow work item", iid)
+		deliver(nil, fmt.Errorf("context canceled before dispatching workflow work item: %w", err))
+	}
+}
+
+// executeActivityAsync is the event-driven form of ExecuteActivity, with the
+// same contract as executeWorkflowAsync.
+func (g *grpcExecutor) executeActivityAsync(ctx context.Context, iid api.InstanceID, e *protos.HistoryEvent, opts ExecuteOptions, done func(*protos.HistoryEvent, error)) {
+	cbBackend, ok := g.backend.(CompletionCallbackBackend)
+	if !ok {
+		done(nil, errors.New("backend does not support completion callbacks"))
+		return
+	}
+
+	key := GetActivityExecutionKey(string(iid), e.EventId)
+	g.pendingActivities.Store(key, &pendingActivity{instanceID: iid, taskID: e.EventId})
+
+	task := e.GetTaskScheduled()
+	req := &protos.ActivityRequest{
+		Name:               task.Name,
+		Version:            task.Version,
+		Input:              task.Input,
+		WorkflowInstance:   &protos.WorkflowInstance{InstanceId: string(iid)},
+		TaskId:             e.EventId,
+		TaskExecutionId:    task.TaskExecutionId,
+		ParentTraceContext: task.ParentTraceContext,
+		PropagatedHistory:  opts.PropagatedHistory,
+	}
+	// Same stale-response guard as executeWorkflowAsync: a mismatched token
+	// is a superseded dispatch's response and must not settle this one.
+	token := uuid.NewString()
+	workItem := &protos.WorkItem{
+		Request: &protos.WorkItem_ActivityRequest{
+			ActivityRequest: req,
+		},
+		CompletionToken: token,
+	}
+
+	wait := &asyncWait{}
+	var deliver func(resp *protos.ActivityResponse, err error)
+	deliver = func(resp *protos.ActivityResponse, err error) {
+		if err == nil && resp.GetCompletionToken() != "" && resp.GetCompletionToken() != token {
+			g.logger.Warnf("%s/%s#%d: discarding stale activity response (completion token mismatch); waiting for the current dispatch's response", iid, task.Name, e.EventId)
+			wait.setDeregister(cbBackend.OnActivityCompletion(req, deliver))
+			return
+		}
+		if !wait.settle() {
+			return
+		}
+		g.pendingActivities.Delete(key)
+		if err != nil {
+			if errors.Is(err, api.ErrTaskCancelled) {
+				done(nil, errors.New("operation aborted"))
+				return
+			}
+			g.logger.Warnf("%s/%s#%d: failed before receiving activity result", iid, task.Name, e.EventId)
+			done(nil, err)
+			return
+		}
+		done(activityResponseEvent(e, task, resp), nil)
+	}
+
+	wait.setDeregister(cbBackend.OnActivityCompletion(req, deliver))
+	wait.setStop(context.AfterFunc(ctx, func() {
+		deliver(nil, ctx.Err())
+	}))
+
+	select {
+	case <-ctx.Done():
+		g.logger.Warnf("%s/%s#%d: context canceled before dispatching activity work item", iid, task.Name, e.EventId)
+		deliver(nil, fmt.Errorf("context canceled before dispatching activity work item: %w", ctx.Err()))
+	case g.workItemQueue <- workItem:
+	}
+}
+
 // ExecuteWorkflow implements Executor
 func (executor *grpcExecutor) ExecuteWorkflow(ctx context.Context, iid api.InstanceID, oldEvents []*protos.HistoryEvent, newEvents []*protos.HistoryEvent, opts ExecuteOptions) (*protos.WorkflowResponse, error) {
 	executor.pendingWorkflows.Store(iid, &pendingWorkflow{instanceID: iid})
@@ -232,9 +437,14 @@ func (executor *grpcExecutor) ExecuteActivity(ctx context.Context, iid api.Insta
 		return nil, err
 	}
 
-	var responseEvent *protos.HistoryEvent
+	return activityResponseEvent(e, task, resp), nil
+}
+
+// activityResponseEvent maps an activity response onto the TaskFailed or
+// TaskCompleted history event the workflow consumes.
+func activityResponseEvent(e *protos.HistoryEvent, task *protos.TaskScheduledEvent, resp *protos.ActivityResponse) *protos.HistoryEvent {
 	if failureDetails := resp.GetFailureDetails(); failureDetails != nil {
-		responseEvent = &protos.HistoryEvent{
+		return &protos.HistoryEvent{
 			EventId:   -1,
 			Timestamp: timestamppb.Now(),
 			EventType: &protos.HistoryEvent_TaskFailed{
@@ -246,22 +456,19 @@ func (executor *grpcExecutor) ExecuteActivity(ctx context.Context, iid api.Insta
 			},
 			Router: e.Router,
 		}
-	} else {
-		responseEvent = &protos.HistoryEvent{
-			EventId:   -1,
-			Timestamp: timestamppb.New(time.Now()),
-			EventType: &protos.HistoryEvent_TaskCompleted{
-				TaskCompleted: &protos.TaskCompletedEvent{
-					TaskScheduledId: resp.TaskId,
-					Result:          resp.Result,
-					TaskExecutionId: task.TaskExecutionId,
-				},
-			},
-			Router: e.Router,
-		}
 	}
-
-	return responseEvent, nil
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: resp.TaskId,
+				Result:          resp.Result,
+				TaskExecutionId: task.TaskExecutionId,
+			},
+		},
+		Router: e.Router,
+	}
 }
 
 // Shutdown implements Executor

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -237,10 +237,10 @@ func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.Instanc
 	deliver = func(resp *protos.WorkflowResponse, err error) {
 		if err == nil && resp.GetCompletionToken() != "" && resp.GetCompletionToken() != token {
 			g.logger.Warnf("%s: discarding stale workflow task response (completion token mismatch); waiting for the current dispatch's response", iid)
-			// Re-register for the real response; registration drains any
-			// parked payload so a response displaced by the stale one is
-			// re-arbitrated rather than stranding on the executor actor.
-			wait.setDeregister(cbBackend.OnWorkflowTaskCompletion(req, deliver))
+			// The registration stays armed: the backend must only remove it
+			// via the deregister closure (run when a delivery settles), never
+			// on delivery itself, so the genuine response cannot race into an
+			// unregistered window while a stale one is being discarded.
 			return
 		}
 		if !wait.settle() {
@@ -308,7 +308,7 @@ func (g *grpcExecutor) executeActivityAsync(ctx context.Context, iid api.Instanc
 	deliver = func(resp *protos.ActivityResponse, err error) {
 		if err == nil && resp.GetCompletionToken() != "" && resp.GetCompletionToken() != token {
 			g.logger.Warnf("%s/%s#%d: discarding stale activity response (completion token mismatch); waiting for the current dispatch's response", iid, task.Name, e.EventId)
-			wait.setDeregister(cbBackend.OnActivityCompletion(req, deliver))
+			// Registration stays armed; see the workflow deliver above.
 			return
 		}
 		if !wait.settle() {

--- a/backend/local/task.go
+++ b/backend/local/task.go
@@ -12,11 +12,13 @@ import (
 type pendingWorkflow struct {
 	response *protos.WorkflowResponse
 	complete chan struct{}
+	cb       func(*protos.WorkflowResponse, error)
 }
 
 type pendingActivity struct {
 	response *protos.ActivityResponse
 	complete chan struct{}
+	cb       func(*protos.ActivityResponse, error)
 }
 
 type TasksBackend struct {
@@ -67,6 +69,17 @@ func (be *TasksBackend) WaitForActivityCompletion(request *protos.ActivityReques
 	}
 }
 
+// OnActivityCompletion implements backend.CompletionCallbackBackend.
+func (be *TasksBackend) OnActivityCompletion(request *protos.ActivityRequest, cb func(*protos.ActivityResponse, error)) func() {
+	key := backend.GetActivityExecutionKey(request.GetWorkflowInstance().GetInstanceId(), request.GetTaskId())
+	pending := &pendingActivity{cb: cb}
+	be.pendingActivities.Store(key, pending)
+
+	return func() {
+		be.pendingActivities.CompareAndDelete(key, pending)
+	}
+}
+
 func (be *TasksBackend) CompleteWorkflowTask(ctx context.Context, response *protos.WorkflowResponse) error {
 	if be.deletePendingWorkflow(response.GetInstanceId(), response) {
 		return nil
@@ -101,6 +114,17 @@ func (be *TasksBackend) WaitForWorkflowTaskCompletion(request *protos.WorkflowRe
 	}
 }
 
+// OnWorkflowTaskCompletion implements backend.CompletionCallbackBackend.
+func (be *TasksBackend) OnWorkflowTaskCompletion(request *protos.WorkflowRequest, cb func(*protos.WorkflowResponse, error)) func() {
+	key := request.GetInstanceId()
+	pending := &pendingWorkflow{cb: cb}
+	be.pendingWorkflows.Store(key, pending)
+
+	return func() {
+		be.pendingWorkflows.CompareAndDelete(key, pending)
+	}
+}
+
 func (be *TasksBackend) deletePendingActivityTask(iid string, taskID int32, res *protos.ActivityResponse) bool {
 	key := backend.GetActivityExecutionKey(iid, taskID)
 	p, ok := be.pendingActivities.LoadAndDelete(key)
@@ -110,6 +134,14 @@ func (be *TasksBackend) deletePendingActivityTask(iid string, taskID int32, res 
 
 	// Note that res can be nil in case of certain failures
 	pending := p.(*pendingActivity)
+	if pending.cb != nil {
+		if res == nil {
+			pending.cb(nil, api.ErrTaskCancelled)
+		} else {
+			pending.cb(res, nil)
+		}
+		return true
+	}
 	pending.response = res
 	close(pending.complete)
 	return true
@@ -123,6 +155,14 @@ func (be *TasksBackend) deletePendingWorkflow(instanceID string, res *protos.Wor
 
 	// Note that res can be nil in case of certain failures
 	pending := p.(*pendingWorkflow)
+	if pending.cb != nil {
+		if res == nil {
+			pending.cb(nil, api.ErrTaskCancelled)
+		} else {
+			pending.cb(res, nil)
+		}
+		return true
+	}
 	pending.response = res
 	close(pending.complete)
 	return true

--- a/backend/local/task.go
+++ b/backend/local/task.go
@@ -34,7 +34,7 @@ func NewTasksBackend() *TasksBackend {
 }
 
 func (be *TasksBackend) CompleteActivityTask(ctx context.Context, response *protos.ActivityResponse) error {
-	if be.deletePendingActivityTask(response.GetInstanceId(), response.GetTaskId(), response) {
+	if be.deliverPendingActivityTask(response.GetInstanceId(), response.GetTaskId(), response) {
 		return nil
 	}
 
@@ -42,7 +42,7 @@ func (be *TasksBackend) CompleteActivityTask(ctx context.Context, response *prot
 }
 
 func (be *TasksBackend) CancelActivityTask(ctx context.Context, instanceID api.InstanceID, taskID int32) error {
-	if be.deletePendingActivityTask(string(instanceID), taskID, nil) {
+	if be.deliverPendingActivityTask(string(instanceID), taskID, nil) {
 		return nil
 	}
 	return api.NewUnknownTaskIDError(instanceID.String(), taskID)
@@ -81,14 +81,14 @@ func (be *TasksBackend) OnActivityCompletion(request *protos.ActivityRequest, cb
 }
 
 func (be *TasksBackend) CompleteWorkflowTask(ctx context.Context, response *protos.WorkflowResponse) error {
-	if be.deletePendingWorkflow(response.GetInstanceId(), response) {
+	if be.deliverPendingWorkflow(response.GetInstanceId(), response) {
 		return nil
 	}
 	return api.NewUnknownInstanceIDError(response.GetInstanceId())
 }
 
 func (be *TasksBackend) CancelWorkflowTask(ctx context.Context, instanceID api.InstanceID) error {
-	if be.deletePendingWorkflow(string(instanceID), nil) {
+	if be.deliverPendingWorkflow(string(instanceID), nil) {
 		return nil
 	}
 	return api.NewUnknownInstanceIDError(instanceID.String())
@@ -125,9 +125,9 @@ func (be *TasksBackend) OnWorkflowTaskCompletion(request *protos.WorkflowRequest
 	}
 }
 
-func (be *TasksBackend) deletePendingActivityTask(iid string, taskID int32, res *protos.ActivityResponse) bool {
+func (be *TasksBackend) deliverPendingActivityTask(iid string, taskID int32, res *protos.ActivityResponse) bool {
 	key := backend.GetActivityExecutionKey(iid, taskID)
-	p, ok := be.pendingActivities.LoadAndDelete(key)
+	p, ok := be.pendingActivities.Load(key)
 	if !ok {
 		return false
 	}
@@ -135,6 +135,11 @@ func (be *TasksBackend) deletePendingActivityTask(iid string, taskID int32, res 
 	// Note that res can be nil in case of certain failures
 	pending := p.(*pendingActivity)
 	if pending.cb != nil {
+		// Callback registrations stay in the map until the executor's arbiter
+		// accepts a delivery and runs the deregister closure. Deleting here
+		// would open a window where a stale-token delivery consumes the only
+		// routing entry while the genuine response races in and is dropped as
+		// unknown, stranding the re-armed callback forever.
 		if res == nil {
 			pending.cb(nil, api.ErrTaskCancelled)
 		} else {
@@ -142,13 +147,18 @@ func (be *TasksBackend) deletePendingActivityTask(iid string, taskID int32, res 
 		}
 		return true
 	}
+	// Channel path: single delivery, the first responder to win the entry
+	// parks the payload; a racing duplicate reports unknown as before.
+	if !be.pendingActivities.CompareAndDelete(key, p) {
+		return false
+	}
 	pending.response = res
 	close(pending.complete)
 	return true
 }
 
-func (be *TasksBackend) deletePendingWorkflow(instanceID string, res *protos.WorkflowResponse) bool {
-	p, ok := be.pendingWorkflows.LoadAndDelete(instanceID)
+func (be *TasksBackend) deliverPendingWorkflow(instanceID string, res *protos.WorkflowResponse) bool {
+	p, ok := be.pendingWorkflows.Load(instanceID)
 	if !ok {
 		return false
 	}
@@ -156,12 +166,17 @@ func (be *TasksBackend) deletePendingWorkflow(instanceID string, res *protos.Wor
 	// Note that res can be nil in case of certain failures
 	pending := p.(*pendingWorkflow)
 	if pending.cb != nil {
+		// See deliverPendingActivityTask: the registration outlives stale
+		// deliveries; only the deregister closure removes it.
 		if res == nil {
 			pending.cb(nil, api.ErrTaskCancelled)
 		} else {
 			pending.cb(res, nil)
 		}
 		return true
+	}
+	if !be.pendingWorkflows.CompareAndDelete(instanceID, p) {
+		return false
 	}
 	pending.response = res
 	close(pending.complete)

--- a/backend/local/task_test.go
+++ b/backend/local/task_test.go
@@ -1,0 +1,118 @@
+package local_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/local"
+)
+
+func activityRequest(iid string, taskID int32) *protos.ActivityRequest {
+	return &protos.ActivityRequest{
+		WorkflowInstance: &protos.WorkflowInstance{InstanceId: iid},
+		TaskId:           taskID,
+	}
+}
+
+func Test_OnActivityCompletion_Delivers(t *testing.T) {
+	be := local.NewTasksBackend()
+
+	var got *protos.ActivityResponse
+	var gotErr error
+	calls := 0
+	dereg := be.OnActivityCompletion(activityRequest("abc", 1), func(resp *protos.ActivityResponse, err error) {
+		calls++
+		got, gotErr = resp, err
+	})
+
+	resp := &protos.ActivityResponse{InstanceId: "abc", TaskId: 1}
+	require.NoError(t, be.CompleteActivityTask(context.Background(), resp))
+	require.Equal(t, 1, calls)
+	require.Same(t, resp, got)
+	require.NoError(t, gotErr)
+
+	// The registration is consumed: a second completion has no target.
+	require.Error(t, be.CompleteActivityTask(context.Background(), resp))
+	require.Equal(t, 1, calls)
+
+	// Deregistering after delivery is a no-op.
+	dereg()
+}
+
+func Test_OnActivityCompletion_Cancelled(t *testing.T) {
+	be := local.NewTasksBackend()
+
+	var gotErr error
+	calls := 0
+	be.OnActivityCompletion(activityRequest("abc", 1), func(resp *protos.ActivityResponse, err error) {
+		calls++
+		gotErr = err
+	})
+
+	require.NoError(t, be.CancelActivityTask(context.Background(), api.InstanceID("abc"), 1))
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, gotErr, api.ErrTaskCancelled)
+}
+
+func Test_OnActivityCompletion_Deregister(t *testing.T) {
+	be := local.NewTasksBackend()
+
+	calls := 0
+	dereg := be.OnActivityCompletion(activityRequest("abc", 1), func(*protos.ActivityResponse, error) {
+		calls++
+	})
+	dereg()
+
+	require.Error(t, be.CompleteActivityTask(context.Background(), &protos.ActivityResponse{InstanceId: "abc", TaskId: 1}))
+	require.Zero(t, calls)
+}
+
+func Test_OnWorkflowTaskCompletion_Delivers(t *testing.T) {
+	be := local.NewTasksBackend()
+
+	var got *protos.WorkflowResponse
+	var gotErr error
+	calls := 0
+	be.OnWorkflowTaskCompletion(&protos.WorkflowRequest{InstanceId: "abc"}, func(resp *protos.WorkflowResponse, err error) {
+		calls++
+		got, gotErr = resp, err
+	})
+
+	resp := &protos.WorkflowResponse{InstanceId: "abc"}
+	require.NoError(t, be.CompleteWorkflowTask(context.Background(), resp))
+	require.Equal(t, 1, calls)
+	require.Same(t, resp, got)
+	require.NoError(t, gotErr)
+}
+
+func Test_OnWorkflowTaskCompletion_Cancelled(t *testing.T) {
+	be := local.NewTasksBackend()
+
+	var gotErr error
+	calls := 0
+	be.OnWorkflowTaskCompletion(&protos.WorkflowRequest{InstanceId: "abc"}, func(resp *protos.WorkflowResponse, err error) {
+		calls++
+		gotErr = err
+	})
+
+	require.NoError(t, be.CancelWorkflowTask(context.Background(), api.InstanceID("abc")))
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, gotErr, api.ErrTaskCancelled)
+}
+
+func Test_OnWorkflowTaskCompletion_Deregister(t *testing.T) {
+	be := local.NewTasksBackend()
+
+	calls := 0
+	dereg := be.OnWorkflowTaskCompletion(&protos.WorkflowRequest{InstanceId: "abc"}, func(*protos.WorkflowResponse, error) {
+		calls++
+	})
+	dereg()
+
+	require.Error(t, be.CompleteWorkflowTask(context.Background(), &protos.WorkflowResponse{InstanceId: "abc"}))
+	require.Zero(t, calls)
+}

--- a/backend/local/task_test.go
+++ b/backend/local/task_test.go
@@ -35,12 +35,18 @@ func Test_OnActivityCompletion_Delivers(t *testing.T) {
 	require.Same(t, resp, got)
 	require.NoError(t, gotErr)
 
-	// The registration is consumed: a second completion has no target.
-	require.Error(t, be.CompleteActivityTask(context.Background(), resp))
-	require.Equal(t, 1, calls)
+	// Delivery does NOT consume the registration: the executor's arbiter
+	// discards stale-token deliveries and keeps waiting on this registration,
+	// so a genuine response arriving after a discarded stale one must still
+	// route (pre-fix, the stale delivery consumed the entry and the genuine
+	// response was dropped as unknown, stranding the waiter forever).
+	require.NoError(t, be.CompleteActivityTask(context.Background(), resp))
+	require.Equal(t, 2, calls)
 
-	// Deregistering after delivery is a no-op.
+	// Only the deregister closure removes the registration.
 	dereg()
+	require.Error(t, be.CompleteActivityTask(context.Background(), resp))
+	require.Equal(t, 2, calls)
 }
 
 func Test_OnActivityCompletion_Cancelled(t *testing.T) {
@@ -87,6 +93,10 @@ func Test_OnWorkflowTaskCompletion_Delivers(t *testing.T) {
 	require.Equal(t, 1, calls)
 	require.Same(t, resp, got)
 	require.NoError(t, gotErr)
+
+	// See the activity variant: delivery must not consume the registration.
+	require.NoError(t, be.CompleteWorkflowTask(context.Background(), resp))
+	require.Equal(t, 2, calls)
 }
 
 func Test_OnWorkflowTaskCompletion_Cancelled(t *testing.T) {

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -27,6 +27,16 @@ type WorkflowExecutor interface {
 		opts ExecuteOptions) (*protos.WorkflowResponse, error)
 }
 
+// asyncWorkflowExecutor is implemented by executors that can deliver the
+// workflow response through a callback instead of blocking in ExecuteWorkflow.
+type asyncWorkflowExecutor interface {
+	canExecuteAsync() bool
+	executeWorkflowAsync(ctx context.Context, iid api.InstanceID, oldEvents []*protos.HistoryEvent, newEvents []*protos.HistoryEvent, opts ExecuteOptions, done func(*protos.WorkflowResponse, error))
+}
+
+// maxContinueAsNewCount bounds the tight continue-as-new re-execution loop.
+const maxContinueAsNewCount = 20
+
 type WorkflowWorkerOptions struct {
 	Backend   Backend
 	Executor  WorkflowExecutor
@@ -158,9 +168,8 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 			// When continuing-as-new, we re-execute the workflow from the beginning with a truncated state in a tight loop
 			// until the workflow performs some non-continue-as-new action.
 			if applyResult.ContinuedAsNew {
-				const MaxContinueAsNewCount = 20
-				if continueAsNewCount >= MaxContinueAsNewCount {
-					return fmt.Errorf("exceeded tight-loop continue-as-new limit of %d iterations", MaxContinueAsNewCount)
+				if continueAsNewCount >= maxContinueAsNewCount {
+					return fmt.Errorf("exceeded tight-loop continue-as-new limit of %d iterations", maxContinueAsNewCount)
 				}
 
 				// Carry the propagation chain forward across the CAN boundary so
@@ -188,6 +197,165 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 		appendCascadeTerminateMessages(wi.State, terminateEvent)
 	}
 	return nil
+}
+
+// ProcessWorkItemAsync implements AsyncTaskProcessor. It mirrors
+// ProcessWorkItem, with the work that follows each workflow execution
+// registered as a completion callback, so no goroutine waits out the app
+// roundtrip. A continue-as-new response starts its next execution from the
+// goroutine that delivered the previous one.
+func (w *workflowProcessor) ProcessWorkItemAsync(ctx context.Context, wi *WorkflowWorkItem, done func(error)) bool {
+	if asyncExecutor, ok := w.executor.(asyncWorkflowExecutor); !ok || !asyncExecutor.canExecuteAsync() {
+		return false
+	}
+
+	w.logger.Debugf("%v: received work item with %d new event(s): %v", wi.InstanceID, len(wi.NewEvents), helpers.HistoryListSummary(wi.NewEvents))
+
+	if wi.State == nil {
+		state, err := w.be.GetWorkflowRuntimeState(ctx, wi)
+		if err != nil {
+			done(fmt.Errorf("failed to load workflow state: %w", err))
+			return true
+		}
+		wi.State = state
+	}
+	w.logger.Debugf("%v: got workflow runtime state: %s", wi.InstanceID, getWorkflowStateDescription(wi))
+
+	var terminateEvent *protos.ExecutionTerminatedEvent
+	for _, e := range wi.NewEvents {
+		if et := e.GetExecutionTerminated(); et != nil {
+			terminateEvent = et
+			break
+		}
+	}
+
+	spanCtx, span, ok := w.applyWorkItem(ctx, wi)
+	if !ok {
+		if terminateEvent != nil && runtimestate.IsCompleted(wi.State) {
+			appendCascadeTerminateMessages(wi.State, terminateEvent)
+		}
+		done(nil)
+		return true
+	}
+
+	turn := &workflowTurn{
+		processor:      w,
+		wi:             wi,
+		ctx:            spanCtx,
+		span:           span,
+		terminateEvent: terminateEvent,
+		done:           done,
+	}
+	turn.execute()
+	return true
+}
+
+// workflowTurn carries a workflow work item through its execute-apply loop in
+// callback form: execute hands the response to applyResponse, which either
+// finishes the work item or, on continue-as-new, executes again.
+type workflowTurn struct {
+	processor          *workflowProcessor
+	wi                 *WorkflowWorkItem
+	ctx                context.Context
+	span               trace.Span
+	terminateEvent     *protos.ExecutionTerminatedEvent
+	continueAsNewCount int
+	done               func(error)
+}
+
+func (t *workflowTurn) execute() {
+	w := t.processor
+	wi := t.wi
+
+	if t.continueAsNewCount > 0 {
+		w.logger.Debugf("%v: continuing-as-new with %d event(s): %s", wi.InstanceID, len(wi.State.NewEvents), helpers.HistoryListSummary(wi.State.NewEvents))
+	} else {
+		w.logger.Debugf("%v: invoking workflow", wi.InstanceID)
+	}
+
+	executor := w.executor
+	if w.inProcessExecutor != nil && w.inProcessNamePrefix != "" {
+		if name := wi.State.GetStartEvent().GetName(); strings.HasPrefix(name, w.inProcessNamePrefix) {
+			executor = w.inProcessExecutor
+		}
+	}
+
+	execOpts := ExecuteOptions{PropagatedHistory: wi.IncomingHistory}
+
+	// An executor that cannot deliver by callback (e.g. the in-process one,
+	// which runs the workflow code inline) is invoked synchronously on the
+	// current goroutine.
+	if asyncExecutor, ok := executor.(asyncWorkflowExecutor); ok && asyncExecutor.canExecuteAsync() {
+		asyncExecutor.executeWorkflowAsync(t.ctx, wi.InstanceID, wi.State.OldEvents, wi.State.NewEvents, execOpts, func(results *protos.WorkflowResponse, err error) {
+			t.applyResponse(results, err, execOpts)
+		})
+		return
+	}
+
+	results, err := executor.ExecuteWorkflow(t.ctx, wi.InstanceID, wi.State.OldEvents, wi.State.NewEvents, execOpts)
+	t.applyResponse(results, err, execOpts)
+}
+
+func (t *workflowTurn) applyResponse(results *protos.WorkflowResponse, err error, execOpts ExecuteOptions) {
+	w := t.processor
+	wi := t.wi
+
+	if err != nil {
+		t.finish(fmt.Errorf("error executing workflow: %w", err))
+		return
+	}
+	w.logger.Debugf("%v: workflow returned %d action(s): %s", wi.InstanceID, len(results.Actions), helpers.ActionListSummary(results.Actions))
+
+	if version := results.GetVersion(); version != nil && (version.GetPatches() != nil || version.Name != nil) {
+		for _, e := range wi.State.NewEvents {
+			if os := e.GetWorkflowStarted(); os != nil {
+				os.Version = version
+				if len(version.GetPatches()) > 0 {
+					t.span.SetAttributes(attribute.StringSlice("applied_patches", version.GetPatches()))
+				}
+				break
+			}
+		}
+	}
+
+	applyResult, err := w.applier.Actions(wi.State, results.CustomStatus, results.Actions, helpers.TraceContextFromSpan(t.span), execOpts.PropagatedHistory)
+	if err != nil {
+		t.finish(fmt.Errorf("failed to apply the execution result actions: %w", err))
+		return
+	}
+
+	wi.OutgoingHistory = applyResult.OutgoingHistory
+
+	if applyResult.ContinuedAsNew {
+		if t.continueAsNewCount >= maxContinueAsNewCount {
+			t.finish(fmt.Errorf("exceeded tight-loop continue-as-new limit of %d iterations", maxContinueAsNewCount))
+			return
+		}
+
+		if applyResult.NewIncomingHistory != nil {
+			wi.IncomingHistory = applyResult.NewIncomingHistory
+		}
+
+		w.endWorkflowSpan(t.ctx, wi, t.span, true)
+		t.ctx, t.span = w.startOrResumeWorkflowSpan(t.ctx, wi)
+		t.continueAsNewCount++
+		t.execute()
+		return
+	}
+
+	if runtimestate.IsCompleted(wi.State) {
+		name, _ := runtimestate.Name(wi.State)
+		w.logger.Infof("%v: '%s' completed with a %s status.", wi.InstanceID, name, helpers.ToRuntimeStatusString(runtimestate.RuntimeStatus(wi.State)))
+	}
+	t.finish(nil)
+}
+
+func (t *workflowTurn) finish(err error) {
+	t.processor.endWorkflowSpan(t.ctx, t.wi, t.span, false)
+	if err == nil && t.terminateEvent != nil && runtimestate.IsCompleted(t.wi.State) {
+		appendCascadeTerminateMessages(t.wi.State, t.terminateEvent)
+	}
+	t.done(err)
 }
 
 // CompleteWorkItem implements TaskProcessor

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -21,6 +21,19 @@ type TaskProcessor[T WorkItem] interface {
 	CompleteWorkItem(context.Context, T) error
 }
 
+// AsyncTaskProcessor is an optional extension of TaskProcessor for processors
+// that can hand off a work item without a goroutine parked on the completion.
+//
+// When ProcessWorkItemAsync returns true it has taken ownership of the work
+// item and invokes done exactly once, with the same error ProcessWorkItem
+// would have returned, possibly before returning and possibly from the
+// goroutine that delivers the work item's completion. When it returns false it
+// has had no side effects and the caller must fall back to ProcessWorkItem.
+type AsyncTaskProcessor[T WorkItem] interface {
+	TaskProcessor[T]
+	ProcessWorkItemAsync(ctx context.Context, wi T, done func(error)) bool
+}
+
 type worker[T WorkItem] struct {
 	logger Logger
 
@@ -116,13 +129,29 @@ func (w *worker[T]) Start(ctx context.Context) {
 
 			w.wg.Add(1)
 			go func() {
-				defer func() {
-					if w.parallelLock != nil {
-						<-w.parallelLock
-					}
-					w.wg.Done()
-				}()
-				w.processWorkItem(ctx, wi)
+				// finish runs the completion tail exactly once on whichever
+				// goroutine delivers the result: this one for the blocking
+				// path, the completion-delivering goroutine for the async
+				// path. The parallelLock slot acquired above is held until
+				// then and released here on every path.
+				var once sync.Once
+				finish := func(err error) {
+					once.Do(func() {
+						w.finishWorkItem(ctx, wi, err)
+						if w.parallelLock != nil {
+							<-w.parallelLock
+						}
+						w.wg.Done()
+					})
+				}
+
+				w.logger.Debugf("%v: processing work item: %s", w.Name(), wi)
+
+				if ap, ok := w.processor.(AsyncTaskProcessor[T]); ok && ap.ProcessWorkItemAsync(ctx, wi, finish) {
+					return
+				}
+
+				finish(w.processor.ProcessWorkItem(ctx, wi))
 			}()
 		}
 	}()
@@ -133,10 +162,8 @@ func (w *worker[T]) StopAndDrain() {
 	w.wg.Wait()
 }
 
-func (w *worker[T]) processWorkItem(ctx context.Context, wi T) {
-	w.logger.Debugf("%v: processing work item: %s", w.Name(), wi)
-
-	if err := w.processor.ProcessWorkItem(ctx, wi); err != nil {
+func (w *worker[T]) finishWorkItem(ctx context.Context, wi T, err error) {
+	if err != nil {
 		w.logger.Errorf("%v: failed to process work item: %v", w.Name(), err)
 		if err = w.processor.AbandonWorkItem(context.Background(), wi); err != nil {
 			w.logger.Errorf("%v: failed to abandon work item: %v", w.Name(), err)

--- a/client/worker_grpc.go
+++ b/client/worker_grpc.go
@@ -184,9 +184,9 @@ func (c *TaskHubGrpcClient) StartWorkItemListener(ctx context.Context, r *task.T
 				// Capture this stream's cancel so the handler tears down the
 				// stream it arrived on, not a later reconnected one.
 				teardownStream := streamCancel
-				go c.processWorkflowWorkItem(ctx, executor, historyCache, orchReq, teardownStream)
+				go c.processWorkflowWorkItem(ctx, executor, historyCache, orchReq, workItem.GetCompletionToken(), teardownStream)
 			} else if actReq := workItem.GetActivityRequest(); actReq != nil {
-				go c.processActivityWorkItem(ctx, executor, actReq)
+				go c.processActivityWorkItem(ctx, executor, actReq, workItem.GetCompletionToken())
 			} else {
 				c.logger.Warnf("received unknown work item type: %v", workItem)
 			}
@@ -200,6 +200,7 @@ func (c *TaskHubGrpcClient) processWorkflowWorkItem(
 	executor backend.Executor,
 	historyCache *workflowHistoryCache,
 	workItem *protos.WorkflowRequest,
+	completionToken string,
 	teardownStream context.CancelFunc,
 ) {
 	iid := api.InstanceID(workItem.InstanceId)
@@ -242,7 +243,10 @@ func (c *TaskHubGrpcClient) processWorkflowWorkItem(
 		}
 	}
 
-	resp := protos.WorkflowResponse{InstanceId: workItem.InstanceId}
+	// Echo the dispatch's completion token so the sidecar can correlate this
+	// response with the dispatch that requested it and discard stale or
+	// duplicate deliveries.
+	resp := protos.WorkflowResponse{InstanceId: workItem.InstanceId, CompletionToken: completionToken}
 	if err != nil {
 		// NOTE: At the time of writing, there's no known case where this error is returned.
 		//       We add error handling here anyways, just in case.
@@ -280,6 +284,7 @@ func (c *TaskHubGrpcClient) processActivityWorkItem(
 	ctx context.Context,
 	executor backend.Executor,
 	req *protos.ActivityRequest,
+	completionToken string,
 ) {
 	opts := backend.ExecuteOptions{
 		PropagatedHistory: req.GetPropagatedHistory(),
@@ -305,7 +310,7 @@ func (c *TaskHubGrpcClient) processActivityWorkItem(
 	}
 	result, err := executor.ExecuteActivity(ctx, api.InstanceID(req.WorkflowInstance.InstanceId), event, opts)
 
-	resp := protos.ActivityResponse{InstanceId: req.WorkflowInstance.InstanceId, TaskId: req.TaskId}
+	resp := protos.ActivityResponse{InstanceId: req.WorkflowInstance.InstanceId, TaskId: req.TaskId, CompletionToken: completionToken}
 	if err != nil {
 		resp.FailureDetails = &protos.TaskFailureDetails{
 			ErrorType:    fmt.Sprintf("%T", err),

--- a/client/worker_grpc.go
+++ b/client/worker_grpc.go
@@ -184,6 +184,9 @@ func (c *TaskHubGrpcClient) StartWorkItemListener(ctx context.Context, r *task.T
 				// Capture this stream's cancel so the handler tears down the
 				// stream it arrived on, not a later reconnected one.
 				teardownStream := streamCancel
+				if c.statefulHistoryEnabled() {
+					historyCache.noteDispatch(api.InstanceID(orchReq.GetInstanceId()), workItem.GetCompletionToken())
+				}
 				go c.processWorkflowWorkItem(ctx, executor, historyCache, orchReq, workItem.GetCompletionToken(), teardownStream)
 			} else if actReq := workItem.GetActivityRequest(); actReq != nil {
 				go c.processActivityWorkItem(ctx, executor, actReq, workItem.GetCompletionToken())
@@ -234,10 +237,15 @@ func (c *TaskHubGrpcClient) processWorkflowWorkItem(
 	// prefix is exactly the committed history we just replayed (never the
 	// not-yet-committed NewEvents). Drop it once the instance completes or
 	// continues-as-new, since its history no longer extends this prefix. Skipped
-	// entirely when the stateful-history optimization is disabled.
-	if err == nil && c.statefulHistoryEnabled() {
+	// entirely when the stateful-history optimization is disabled, and skipped
+	// when this dispatch has been superseded: the sidecar discards a stale
+	// handler's RESPONSE by completion token, but the cache write below would
+	// otherwise overwrite the newer dispatch's prefix and poison the next
+	// delta reconstruction.
+	if err == nil && c.statefulHistoryEnabled() && historyCache.isLatestDispatch(iid, completionToken) {
 		if workflowHistoryReset(results) {
 			historyCache.delete(iid)
+			historyCache.forgetDispatch(iid)
 		} else {
 			historyCache.put(iid, pastEvents)
 		}

--- a/client/worker_history.go
+++ b/client/worker_history.go
@@ -165,9 +165,10 @@ func (h *workflowHistoryCache) noteDispatch(iid api.InstanceID, token string) {
 	h.latestTokens.Store(iid, token)
 }
 
-// isLatestDispatch reports whether token still belongs to the newest received
-// dispatch for iid. An empty stored token (never noted) accepts any token so
-// non-streamed paths keep their previous behavior.
+// isLatestDispatch reports whether token still belongs to the newest
+// dispatch received for iid. An instance with no recorded dispatch accepts
+// any token, so paths that never call noteDispatch keep their previous
+// behavior.
 func (h *workflowHistoryCache) isLatestDispatch(iid api.InstanceID, token string) bool {
 	v, ok := h.latestTokens.Load(iid)
 	if !ok {

--- a/client/worker_history.go
+++ b/client/worker_history.go
@@ -116,8 +116,15 @@ func historyBytes(events []*protos.HistoryEvent) int64 {
 // reclaimed by a TTL janitor (see runJanitor), on completion, and by least-recently-
 // used eviction once either the instance-count cap or the byte budget is exceeded.
 type workflowHistoryCache struct {
-	mu            sync.Mutex
-	entries       map[api.InstanceID]*cachedWorkflowHistory
+	mu      sync.Mutex
+	entries map[api.InstanceID]*cachedWorkflowHistory
+	// latestTokens maps an instance to the completion token of its most
+	// recently received dispatch. Cache writes are gated on it: a handler
+	// whose dispatch has been superseded (redelivery, or a dispatch on a
+	// reconnected stream while the old handler still runs) must not commit
+	// its prefix over the newer dispatch's. Deliberately NOT cleared by
+	// reset(): it must survive reconnects to fence exactly those handlers.
+	latestTokens  sync.Map
 	totalBytes    int64
 	ttl           time.Duration
 	sweepInterval time.Duration
@@ -151,6 +158,28 @@ func newWorkflowHistoryCache(cfg workflowHistoryCacheConfig) *workflowHistoryCac
 		maxBytes:      maxBytes,
 		now:           time.Now,
 	}
+}
+
+// noteDispatch records that token is the newest dispatch for iid.
+func (h *workflowHistoryCache) noteDispatch(iid api.InstanceID, token string) {
+	h.latestTokens.Store(iid, token)
+}
+
+// isLatestDispatch reports whether token still belongs to the newest received
+// dispatch for iid. An empty stored token (never noted) accepts any token so
+// non-streamed paths keep their previous behavior.
+func (h *workflowHistoryCache) isLatestDispatch(iid api.InstanceID, token string) bool {
+	v, ok := h.latestTokens.Load(iid)
+	if !ok {
+		return true
+	}
+	return v.(string) == token
+}
+
+// forgetDispatch drops the newest-dispatch marker, for instances whose
+// history reached a terminal state.
+func (h *workflowHistoryCache) forgetDispatch(iid api.InstanceID) {
+	h.latestTokens.Delete(iid)
 }
 
 func (h *workflowHistoryCache) get(iid api.InstanceID) ([]*protos.HistoryEvent, bool) {

--- a/client/worker_history_test.go
+++ b/client/worker_history_test.go
@@ -297,3 +297,29 @@ func TestWorkflowHistoryCache_TTLSlidingOnPut(t *testing.T) {
 	assert.True(t, ok)
 	assert.Len(t, got, 3, "the refreshed entry survives and holds the latest history")
 }
+
+func TestHistoryCache_SupersededDispatchCannotWrite(t *testing.T) {
+	// A handler whose dispatch has been superseded (redelivery, or a new
+	// dispatch after a stream reconnect while the old handler still runs)
+	// must not commit its prefix over the newer dispatch's: the sidecar
+	// rejects its RESPONSE by completion token, but the local cache write
+	// would otherwise poison the next delta reconstruction.
+	cache := newWorkflowHistoryCache(workflowHistoryCacheConfig{})
+	iid := api.InstanceID("wf1")
+
+	cache.noteDispatch(iid, "token-1")
+	require.True(t, cache.isLatestDispatch(iid, "token-1"))
+
+	// A newer dispatch supersedes token-1, even across a stream reset.
+	cache.reset()
+	cache.noteDispatch(iid, "token-2")
+	require.False(t, cache.isLatestDispatch(iid, "token-1"))
+	require.True(t, cache.isLatestDispatch(iid, "token-2"))
+
+	// Terminal state clears the marker; anything routes again.
+	cache.forgetDispatch(iid)
+	require.True(t, cache.isLatestDispatch(iid, "token-1"))
+
+	// Instances never noted (non-streamed paths) always pass the gate.
+	require.True(t, cache.isLatestDispatch(api.InstanceID("other"), "any"))
+}

--- a/tests/grpc/grpc_test.go
+++ b/tests/grpc/grpc_test.go
@@ -197,6 +197,34 @@ func Test_Grpc_HelloWorkflow(t *testing.T) {
 
 }
 
+func Test_Grpc_ContinueAsNew(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddWorkflowN("ContinueAsNewGrpc", func(ctx *task.WorkflowContext) (any, error) {
+		var input int32
+		if err := ctx.GetInput(&input); err != nil {
+			return nil, err
+		}
+		if input < 10 {
+			ctx.ContinueAsNew(input + 1)
+		}
+		return input, nil
+	})
+
+	cancelListener := startGrpcListener(t, r)
+	defer cancelListener()
+
+	id, err := grpcClient.ScheduleNewWorkflow(ctx, "ContinueAsNewGrpc", api.WithInput(0))
+	require.NoError(t, err)
+	timeoutCtx, cancelTimeout := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelTimeout()
+	metadata, err := grpcClient.WaitForWorkflowCompletion(timeoutCtx, id, api.WithFetchPayloads(true))
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(metadata))
+	assert.Equal(t, `10`, metadata.Output.Value)
+
+	require.NoError(t, grpcClient.PurgeWorkflowState(ctx, id))
+}
+
 func Test_Grpc_SuspendResume(t *testing.T) {
 	const eventCount = 10
 

--- a/tests/worker_async_test.go
+++ b/tests/worker_async_test.go
@@ -1,0 +1,196 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/tests/mocks"
+)
+
+// asyncTaskProcessor wraps the test processor with an AsyncTaskProcessor
+// implementation whose completions are delivered by the test, standing in for
+// the goroutine that delivers a real work item completion.
+type asyncTaskProcessor struct {
+	*mocks.TestTaskProcessor[*backend.ActivityWorkItem]
+
+	// cancelOnCtxDone emulates the executor's context watcher, which settles
+	// an in-flight item with the context error when the worker shuts down.
+	cancelOnCtxDone bool
+
+	mu   sync.Mutex
+	done []func(error)
+}
+
+func newAsyncTaskProcessor(cancelOnCtxDone bool) *asyncTaskProcessor {
+	return &asyncTaskProcessor{
+		TestTaskProcessor: mocks.NewTestTaskPocessor[*backend.ActivityWorkItem]("asynctest"),
+		cancelOnCtxDone:   cancelOnCtxDone,
+	}
+}
+
+func (p *asyncTaskProcessor) ProcessWorkItemAsync(ctx context.Context, wi *backend.ActivityWorkItem, done func(error)) bool {
+	p.mu.Lock()
+	p.done = append(p.done, done)
+	p.mu.Unlock()
+	if p.cancelOnCtxDone {
+		context.AfterFunc(ctx, func() {
+			done(ctx.Err())
+		})
+	}
+	return true
+}
+
+func (p *asyncTaskProcessor) inFlight() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.done)
+}
+
+func (p *asyncTaskProcessor) takeAll() []func(error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	done := p.done
+	p.done = nil
+	return done
+}
+
+func Test_TaskWorkerAsync_ConcurrentCompletions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tp := newAsyncTaskProcessor(false)
+	items := make([]*backend.ActivityWorkItem, 8)
+	for i := range items {
+		items[i] = &backend.ActivityWorkItem{SequenceNumber: int64(i + 1)}
+	}
+	tp.AddWorkItems(items...)
+
+	worker := backend.NewTaskWorker[*backend.ActivityWorkItem](tp, logger, backend.WithMaxParallelism(4))
+	worker.Start(ctx)
+
+	// All four semaphore slots fill, and no fifth item is handed out while
+	// they are held.
+	require.Eventually(t, func() bool { return tp.inFlight() == 4 }, 2*time.Second, 10*time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, 4, tp.inFlight())
+	require.Len(t, tp.PendingWorkItems(), 4)
+
+	// Deliver the four completions concurrently, as separate delivery
+	// goroutines would.
+	var wg sync.WaitGroup
+	for _, done := range tp.takeAll() {
+		wg.Add(1)
+		go func(done func(error)) {
+			defer wg.Done()
+			done(nil)
+		}(done)
+	}
+	wg.Wait()
+
+	// The released slots admit the remaining four items.
+	require.Eventually(t, func() bool { return tp.inFlight() == 4 }, 2*time.Second, 10*time.Millisecond)
+	for _, done := range tp.takeAll() {
+		done(nil)
+	}
+
+	require.Eventually(t, func() bool { return len(tp.CompletedWorkItems()) == 8 }, 2*time.Second, 10*time.Millisecond)
+
+	worker.StopAndDrain()
+
+	require.Len(t, tp.CompletedWorkItems(), 8)
+	require.Empty(t, tp.AbandonedWorkItems())
+	require.Empty(t, tp.PendingWorkItems())
+}
+
+func Test_TaskWorkerAsync_SemaphoreReleasedOnError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tp := newAsyncTaskProcessor(false)
+	first := &backend.ActivityWorkItem{SequenceNumber: 1}
+	second := &backend.ActivityWorkItem{SequenceNumber: 2}
+	tp.AddWorkItems(first, second)
+
+	worker := backend.NewTaskWorker[*backend.ActivityWorkItem](tp, logger, backend.WithMaxParallelism(1))
+	worker.Start(ctx)
+
+	require.Eventually(t, func() bool { return tp.inFlight() == 1 }, 2*time.Second, 10*time.Millisecond)
+
+	// Failing the first item must abandon it and release its slot, or the
+	// second item can never start.
+	tp.takeAll()[0](errors.New("dummy processing error"))
+
+	require.Eventually(t, func() bool {
+		return len(tp.AbandonedWorkItems()) == 1 && tp.inFlight() == 1
+	}, 2*time.Second, 10*time.Millisecond)
+	require.Equal(t, first, tp.AbandonedWorkItems()[0])
+
+	tp.takeAll()[0](nil)
+	require.Eventually(t, func() bool { return len(tp.CompletedWorkItems()) == 1 }, 2*time.Second, 10*time.Millisecond)
+	require.Equal(t, second, tp.CompletedWorkItems()[0])
+
+	worker.StopAndDrain()
+}
+
+func Test_TaskWorkerAsync_ShutdownDrainsInFlight(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tp := newAsyncTaskProcessor(false)
+	tp.AddWorkItems(&backend.ActivityWorkItem{SequenceNumber: 1})
+
+	worker := backend.NewTaskWorker[*backend.ActivityWorkItem](tp, logger, backend.WithMaxParallelism(1))
+	worker.Start(ctx)
+
+	require.Eventually(t, func() bool { return tp.inFlight() == 1 }, 2*time.Second, 10*time.Millisecond)
+
+	drained := make(chan struct{})
+	go func() {
+		worker.StopAndDrain()
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+		t.Fatal("StopAndDrain returned while a work item was still in flight")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	tp.takeAll()[0](nil)
+
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopAndDrain did not finish after the in-flight item completed")
+	}
+
+	require.Len(t, tp.CompletedWorkItems(), 1)
+	require.Empty(t, tp.AbandonedWorkItems())
+}
+
+func Test_TaskWorkerAsync_ShutdownCancelsViaContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tp := newAsyncTaskProcessor(true)
+	tp.AddWorkItems(&backend.ActivityWorkItem{SequenceNumber: 1})
+
+	worker := backend.NewTaskWorker[*backend.ActivityWorkItem](tp, logger, backend.WithMaxParallelism(1))
+	worker.Start(ctx)
+
+	require.Eventually(t, func() bool { return tp.inFlight() == 1 }, 2*time.Second, 10*time.Millisecond)
+
+	// The context watcher settles the in-flight item with the context error,
+	// so the drain completes without an external delivery and the item is
+	// abandoned.
+	worker.StopAndDrain()
+
+	require.Len(t, tp.AbandonedWorkItems(), 1)
+	require.Empty(t, tp.CompletedWorkItems())
+}


### PR DESCRIPTION
The task worker spawned one goroutine per work item that parked inside WaitForWorkflowTaskCompletion / WaitForActivityCompletion for the entire app roundtrip, pairing every in-flight item with a second parked goroutine (2.0 goroutines per item, invariant across all 33 collapse dumps). At collapse  that waiter population made goroutine count a linear function of backlog: stack scanning plus runtime.malg accounted for 17.9 percent of collapsed live heap and about half of markroot/scanstack CPU.

Completions now run event-driven on the goroutine that already delivers them (the CompleteWorkflowTask / CompleteActivityTask RPC path):

- Backend gains an optional CompletionCallbackBackend interface that registers a completion callback instead of blocking a waiter; the local TasksBackend (and therefore sqlite/postgres) implements it.
- grpcExecutor gains executeWorkflowAsync / executeActivityAsync, which register the continuation, dispatch, and return; an asyncWait arbiter settles exactly one of backend delivery, cancellation, context error, or dispatch failure, and context.AfterFunc replaces the parked select for shutdown draining.
- The workflow and activity processors implement ProcessWorkItemAsync, carrying the post-wait work (applier, continue-as-new loop, spans, complete/abandon) as a callback chain with unchanged semantics.
- The worker runs the completion tail through a once-guarded finish closure, so the parallelLock slot is held for the full logical lifetime of the item and released exactly once on completion, error, abandon, and shutdown paths; StopAndDrain still waits for in-flight items.

Because the async callbacks are keyed by instance (workflow) or instance+task (activity), a completion from a superseded dispatch of the same key (a duplicate forward delivery, or a response parked by an aborted attempt) could settle a later dispatch with a response computed from an older history prefix. Each dispatch therefore carries a fresh completion token on the WorkItem: the worker echoes it back on WorkflowResponse and ActivityResponse, and the executor discards a mismatched-token response and re-registers for the current dispatch's token, draining any displaced parked payload. No wire change: the completionToken fields already exist in the protos, and workers that do not echo tokens send an empty one and keep uncorrelated matching. The pre-existing blocking ExecuteWorkflow path stays uncorrelated as before; that is acceptable because dapr consumes the async CompletionCallbackBackend path introduced here.

The pre-dispatch goroutine still exists but dies once the item is handed to the stream, taking goroutines per in-flight item from 2 to 1 and halving the count-vs-backlog slope. Backends without callback support (dapr ClusterTasksBackend today) keep the blocking path unchanged.

Backwards compatible with workers that do not echo CompletionToken: the stale-response guard only engages for a non-empty mismatched token (resp.GetCompletionToken() != "" && != token), so a legacy SDK's empty echo settles completions exactly as before this change. Completion routing is keyed on instance ID, never the token. Legacy workers therefore keep pre-change behavior without the new stale-dispatch protection, which they gain when their SDK starts echoing the token; the wire fields themselves predate this change.