### PR TITLE
honour ExecutionTerminated anywhere in the work item batch

### DIFF
--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -139,6 +139,23 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 				}
 			}
 
+			// A terminate in this batch must never be lost to ContinueAsNew.
+			// Strip any continue-as-new completion before applying actions:
+			// applying it would replace the state with a fresh generation,
+			// so the forced termination below would terminate that synthetic
+			// generation and the wipe would discard the child workflow
+			// history that cascade termination reads.
+			if terminateEvent != nil {
+				actions := results.Actions[:0]
+				for _, a := range results.Actions {
+					if co := a.GetCompleteWorkflow(); co != nil && co.WorkflowStatus == protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW {
+						continue
+					}
+					actions = append(actions, a)
+				}
+				results.Actions = actions
+			}
+
 			// Apply the workflow outputs to the workflow state. The received
 			// propagated history is passed through so the applier can assemble
 			// outgoing lineage propagation for children/activities.
@@ -158,12 +175,6 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 			// When continuing-as-new, we re-execute the workflow from the beginning with a truncated state in a tight loop
 			// until the workflow performs some non-continue-as-new action.
 			if applyResult.ContinuedAsNew {
-				if terminateEvent != nil {
-					// A terminate in this batch must never be lost to
-					// ContinueAsNew; fall through to the forced termination
-					// below instead of starting a new generation.
-					break
-				}
 				const MaxContinueAsNewCount = 20
 				if continueAsNewCount >= MaxContinueAsNewCount {
 					return fmt.Errorf("exceeded tight-loop continue-as-new limit of %d iterations", MaxContinueAsNewCount)

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -158,6 +158,12 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 			// When continuing-as-new, we re-execute the workflow from the beginning with a truncated state in a tight loop
 			// until the workflow performs some non-continue-as-new action.
 			if applyResult.ContinuedAsNew {
+				if terminateEvent != nil {
+					// A terminate in this batch must never be lost to
+					// ContinueAsNew; fall through to the forced termination
+					// below instead of starting a new generation.
+					break
+				}
 				const MaxContinueAsNewCount = 20
 				if continueAsNewCount >= MaxContinueAsNewCount {
 					return fmt.Errorf("exceeded tight-loop continue-as-new limit of %d iterations", MaxContinueAsNewCount)
@@ -182,6 +188,31 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 				w.logger.Infof("%v: '%s' completed with a %s status.", wi.InstanceID, name, helpers.ToRuntimeStatusString(runtimestate.RuntimeStatus(wi.State)))
 			}
 			break
+		}
+
+		// The work item carried an ExecutionTerminated event but the executor
+		// did not complete the workflow, e.g. because the terminate was not
+		// the last event in the batch or the workflow tried to
+		// continue-as-new. The terminate event is consumed with this work
+		// item and can never be re-delivered, so enforce it here: drop the
+		// doomed execution's pending work and complete as TERMINATED.
+		if terminateEvent != nil && !runtimestate.IsCompleted(wi.State) {
+			w.logger.Warnf("%v: workflow was terminated but the executor did not complete it; forcing termination", wi.InstanceID)
+			wi.State.PendingTasks = nil
+			wi.State.PendingTimers = nil
+			wi.State.PendingMessages = nil
+			forced := []*protos.WorkflowAction{{
+				Id: -1,
+				WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+					CompleteWorkflow: &protos.CompleteWorkflowAction{
+						WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED,
+						Result:         terminateEvent.Input,
+					},
+				},
+			}}
+			if _, err := w.applier.Actions(wi.State, wi.State.CustomStatus, forced, helpers.TraceContextFromSpan(span), nil); err != nil {
+				return fmt.Errorf("failed to apply forced termination: %w", err)
+			}
 		}
 	}
 	if terminateEvent != nil && runtimestate.IsCompleted(wi.State) {

--- a/backend/runtimestate/applier.go
+++ b/backend/runtimestate/applier.go
@@ -74,6 +74,12 @@ func (a *Applier) Actions(s *protos.WorkflowRuntimeState, customStatus *wrappers
 		}
 
 		if completedAction := action.GetCompleteWorkflow(); completedAction != nil {
+			// A completion already applied in this pass wins: a later
+			// completion, including ContinueAsNew, must not override or
+			// wipe it.
+			if s.CompletedEvent != nil {
+				continue
+			}
 			if completedAction.WorkflowStatus == protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW {
 				// Capture a propagated chunk from the prior generation BEFORE we
 				// wipe state, so the new generation can continue the chain

--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -1134,6 +1134,13 @@ func (ctx *WorkflowContext) actions() []*protos.WorkflowAction {
 
 	var actions []*protos.WorkflowAction
 	for _, a := range ctx.pendingActions {
+		// A terminated workflow must not start any new work: emit only the
+		// completion action and keep everything else withheld, in particular
+		// tasks and timers that suspension had suppressed before the
+		// terminate arrived.
+		if ctx.isTerminated && a.GetCompleteWorkflow() == nil {
+			continue
+		}
 		actions = append(actions, a)
 		if ctx.continuedAsNew && ctx.saveBufferedExternalEvents {
 			if co := a.GetCompleteWorkflow(); co != nil {

--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -45,6 +45,7 @@ type WorkflowContext struct {
 	newEvents           []*protos.HistoryEvent
 	suspendedEvents     []*protos.HistoryEvent
 	isSuspended         bool
+	isTerminated        bool
 	historyIndex        int
 	sequenceNumber      int32
 	pendingActions      map[int32]*protos.WorkflowAction
@@ -256,6 +257,13 @@ func (ctx *WorkflowContext) getNextHistoryEvent() (*protos.HistoryEvent, bool) {
 }
 
 func (ctx *WorkflowContext) processEvent(e *backend.HistoryEvent) error {
+	// A terminated workflow must not process any further events; in particular
+	// it must never resume the workflow function, which would otherwise emit
+	// actions competing with the termination.
+	if ctx.isTerminated {
+		return nil
+	}
+
 	// Buffer certain events if we're in a suspended state
 	if ctx.isSuspended && (e.GetExecutionResumed() == nil && e.GetExecutionTerminated() == nil) {
 		ctx.suspendedEvents = append(ctx.suspendedEvents, e)
@@ -933,10 +941,23 @@ func (ctx *WorkflowContext) onExecutionResumed(er *protos.ExecutionResumedEvent)
 }
 
 func (ctx *WorkflowContext) onExecutionTerminated(et *protos.ExecutionTerminatedEvent) error {
-	if err := ctx.setCompleteInternal(et.Input, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, nil); err != nil {
-		return err
+	ctx.isTerminated = true
+	for id, a := range ctx.pendingActions {
+		co := a.GetCompleteWorkflow()
+		if co == nil {
+			continue
+		}
+		if co.WorkflowStatus == protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW {
+			// ContinueAsNew must never override a terminate.
+			delete(ctx.pendingActions, id)
+			break
+		}
+		// A completion recorded before the terminate wins, matching the
+		// behavior across work items where a completed workflow drops
+		// subsequent terminate events.
+		return nil
 	}
-	return nil
+	return ctx.setCompleteInternal(et.Input, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, nil)
 }
 
 func (ctx *WorkflowContext) setComplete(output any) error {
@@ -1105,7 +1126,9 @@ func (ctx *WorkflowContext) dropOptionalExternalEventTimerAt(atID int32) bool {
 }
 
 func (ctx *WorkflowContext) actions() []*protos.WorkflowAction {
-	if ctx.isSuspended {
+	// A suspended workflow returns no actions, unless it was terminated while
+	// suspended: the termination action must still be emitted.
+	if ctx.isSuspended && !ctx.isTerminated {
 		return nil
 	}
 
@@ -1123,6 +1146,9 @@ func (ctx *WorkflowContext) actions() []*protos.WorkflowAction {
 			}
 		}
 	}
+	sort.Slice(actions, func(i, j int) bool {
+		return actions[i].Id < actions[j].Id
+	})
 	return actions
 }
 

--- a/tests/runtimestate_test.go
+++ b/tests/runtimestate_test.go
@@ -1757,3 +1757,113 @@ func Test_DuplicateEvents(t *testing.T) {
 		return
 	}
 }
+
+// Verifies that a ContinueAsNew action cannot wipe a state that was already completed
+// earlier in the same apply pass, e.g. by a termination.
+func Test_RuntimeState_TerminatedThenContinueAsNew(t *testing.T) {
+	s := runtimestate.NewWorkflowRuntimeState("abc", nil, []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(time.Now()),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "MyWorkflow",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  "abc",
+						ExecutionId: wrapperspb.String(uuid.New().String()),
+					},
+				},
+			},
+		},
+	})
+
+	actions := []*protos.WorkflowAction{
+		{
+			Id: 1,
+			WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+				CompleteWorkflow: &protos.CompleteWorkflowAction{
+					WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED,
+					Result:         wrapperspb.String(`"stop"`),
+				},
+			},
+		},
+		{
+			Id: 2,
+			WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+				CompleteWorkflow: &protos.CompleteWorkflowAction{
+					WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW,
+				},
+			},
+		},
+	}
+
+	applier := runtimestate.NewApplier("example", "")
+	result, err := applier.Actions(s, nil, actions, nil, nil)
+	require.NoError(t, err)
+	require.False(t, result.ContinuedAsNew)
+	require.True(t, runtimestate.IsCompleted(s))
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, runtimestate.RuntimeStatus(s))
+	completions := 0
+	for _, e := range s.NewEvents {
+		if e.GetExecutionCompleted() != nil {
+			completions++
+		}
+	}
+	require.Equal(t, 1, completions)
+}
+
+// Verifies that a duplicate completion action in the same apply pass neither overrides
+// the first completion nor queues a second parent notification message.
+func Test_RuntimeState_DuplicateCompletionSingleParentNotification(t *testing.T) {
+	s := runtimestate.NewWorkflowRuntimeState("child_id", nil, []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(time.Now()),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Child",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  "child_id",
+						ExecutionId: wrapperspb.String(uuid.New().String()),
+					},
+					ParentInstance: &protos.ParentInstanceInfo{
+						TaskScheduledId:  3,
+						Name:             wrapperspb.String("Parent"),
+						WorkflowInstance: &protos.WorkflowInstance{InstanceId: "parent_id"},
+					},
+				},
+			},
+		},
+	})
+
+	actions := []*protos.WorkflowAction{
+		{
+			Id: 1,
+			WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+				CompleteWorkflow: &protos.CompleteWorkflowAction{
+					WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+					Result:         wrapperspb.String(`"done"`),
+				},
+			},
+		},
+		{
+			Id: 2,
+			WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+				CompleteWorkflow: &protos.CompleteWorkflowAction{
+					WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED,
+					Result:         wrapperspb.String(`"stop"`),
+				},
+			},
+		},
+	}
+
+	applier := runtimestate.NewApplier("example", "")
+	result, err := applier.Actions(s, nil, actions, nil, nil)
+	require.NoError(t, err)
+	require.False(t, result.ContinuedAsNew)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, runtimestate.RuntimeStatus(s))
+	output, err := runtimestate.Output(s)
+	require.NoError(t, err)
+	require.Equal(t, `"done"`, output.GetValue())
+	require.Len(t, s.PendingMessages, 1)
+}

--- a/tests/task_executor_test.go
+++ b/tests/task_executor_test.go
@@ -1225,9 +1225,8 @@ func Test_Executor_TerminateWhileSuspended(t *testing.T) {
 	executor := task.NewTaskExecutor(r)
 	results, err := executor.ExecuteWorkflow(ctx, iid, []*protos.HistoryEvent{}, newEvents, backend.ExecuteOptions{})
 	require.NoError(t, err)
-	require.Len(t, results.Actions, 2, "Expected the pending timer and the termination action")
-	require.NotNil(t, results.Actions[0].GetCreateTimer())
-	complete := results.Actions[1].GetCompleteWorkflow()
+	require.Len(t, results.Actions, 1, "Expected only the termination action; work withheld by the suspension must stay withheld")
+	complete := results.Actions[0].GetCompleteWorkflow()
 	require.NotNil(t, complete)
 	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, complete.WorkflowStatus)
 }

--- a/tests/task_executor_test.go
+++ b/tests/task_executor_test.go
@@ -819,3 +819,469 @@ func Test_Executor_Replay_PrePatchIndefiniteWaitForEvent_Multiple(t *testing.T) 
 		require.Nil(t, a.GetCreateTimer(), "No optional CreateTimer must leak through")
 	}
 }
+
+// Verifies that events arriving after an ExecutionTerminated in the same batch do not
+// resume the workflow: the terminate must be the final word regardless of its position.
+func Test_Executor_TerminateStopsSubsequentEvents(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddActivityN("Ping", func(ctx task.ActivityContext) (any, error) {
+		return "pong", nil
+	})
+	r.AddWorkflowN("Workflow", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("Ping").Await(nil); err != nil {
+			return nil, err
+		}
+		if err := ctx.CallActivity("Ping").Await(nil); err != nil {
+			return nil, err
+		}
+		return "done", nil
+	})
+
+	iid := api.InstanceID("abc123")
+	oldEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Workflow",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(uuid.New().String()),
+					},
+				},
+			},
+		},
+		{
+			EventId:   0,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_TaskScheduled{
+				TaskScheduled: &protos.TaskScheduledEvent{Name: "Ping"},
+			},
+		},
+	}
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionTerminated{
+				ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+					Input: wrapperspb.String(`"stop"`),
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_TaskCompleted{
+				TaskCompleted: &protos.TaskCompletedEvent{
+					TaskScheduledId: 0,
+					Result:          wrapperspb.String(`"pong"`),
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, oldEvents, newEvents, backend.ExecuteOptions{})
+	require.NoError(t, err)
+	require.Len(t, results.Actions, 1, "Expected only the termination action")
+	complete := results.Actions[0].GetCompleteWorkflow()
+	require.NotNil(t, complete)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, complete.WorkflowStatus)
+	require.Equal(t, `"stop"`, complete.Result.GetValue())
+}
+
+// Verifies that a TimerFired arriving after an ExecutionTerminated in the same batch
+// does not resume the workflow.
+func Test_Executor_TerminateBeforeTimerFired(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddActivityN("Ping", func(ctx task.ActivityContext) (any, error) {
+		return "pong", nil
+	})
+	r.AddWorkflowN("Workflow", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CreateTimer(5 * time.Second).Await(nil); err != nil {
+			return nil, err
+		}
+		if err := ctx.CallActivity("Ping").Await(nil); err != nil {
+			return nil, err
+		}
+		return "done", nil
+	})
+
+	iid := api.InstanceID("abc123")
+	startTime := time.Now()
+	oldEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Workflow",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(uuid.New().String()),
+					},
+				},
+			},
+		},
+		{
+			EventId:   0,
+			Timestamp: timestamppb.New(startTime),
+			EventType: &protos.HistoryEvent_TimerCreated{
+				TimerCreated: &protos.TimerCreatedEvent{
+					FireAt: timestamppb.New(startTime.Add(5 * time.Second)),
+				},
+			},
+		},
+	}
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime.Add(5 * time.Second)),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime.Add(5 * time.Second)),
+			EventType: &protos.HistoryEvent_ExecutionTerminated{
+				ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+					Input: wrapperspb.String(`"stop"`),
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(startTime.Add(5 * time.Second)),
+			EventType: &protos.HistoryEvent_TimerFired{
+				TimerFired: &protos.TimerFiredEvent{
+					TimerId: 0,
+					FireAt:  timestamppb.New(startTime.Add(5 * time.Second)),
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, oldEvents, newEvents, backend.ExecuteOptions{})
+	require.NoError(t, err)
+	require.Len(t, results.Actions, 1, "Expected only the termination action")
+	complete := results.Actions[0].GetCompleteWorkflow()
+	require.NotNil(t, complete)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, complete.WorkflowStatus)
+}
+
+// Verifies that ContinueAsNew never overrides a terminate delivered in the same batch,
+// regardless of which side of the activity completion the terminate lands on.
+func Test_Executor_TerminateBeatsContinueAsNew(t *testing.T) {
+	newRegistry := func() *task.TaskRegistry {
+		r := task.NewTaskRegistry()
+		r.AddActivityN("Ping", func(ctx task.ActivityContext) (any, error) {
+			return "pong", nil
+		})
+		r.AddWorkflowN("Workflow", func(ctx *task.WorkflowContext) (any, error) {
+			if err := ctx.CallActivity("Ping").Await(nil); err != nil {
+				return nil, err
+			}
+			ctx.ContinueAsNew(nil)
+			return nil, nil
+		})
+		return r
+	}
+
+	iid := api.InstanceID("abc123")
+	oldEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Workflow",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(uuid.New().String()),
+					},
+				},
+			},
+		},
+		{
+			EventId:   0,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_TaskScheduled{
+				TaskScheduled: &protos.TaskScheduledEvent{Name: "Ping"},
+			},
+		},
+	}
+	terminated := &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input: wrapperspb.String(`"stop"`),
+			},
+		},
+	}
+	taskCompleted := &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 0,
+				Result:          wrapperspb.String(`"pong"`),
+			},
+		},
+	}
+	workflowStarted := &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_WorkflowStarted{
+			WorkflowStarted: &protos.WorkflowStartedEvent{},
+		},
+	}
+
+	for name, newEvents := range map[string][]*protos.HistoryEvent{
+		"terminate first": {workflowStarted, terminated, taskCompleted},
+		"terminate last":  {workflowStarted, taskCompleted, terminated},
+	} {
+		t.Run(name, func(t *testing.T) {
+			executor := task.NewTaskExecutor(newRegistry())
+			results, err := executor.ExecuteWorkflow(ctx, iid, oldEvents, newEvents, backend.ExecuteOptions{})
+			require.NoError(t, err)
+			require.Len(t, results.Actions, 1, "Expected only the termination action")
+			complete := results.Actions[0].GetCompleteWorkflow()
+			require.NotNil(t, complete)
+			require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, complete.WorkflowStatus)
+		})
+	}
+}
+
+// Verifies that a workflow which completed normally earlier in the batch keeps its
+// completion when a terminate arrives later in the same batch, matching the behavior
+// across work items where a completed workflow drops subsequent terminates.
+func Test_Executor_CompletionBeforeTerminateWins(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddActivityN("Ping", func(ctx task.ActivityContext) (any, error) {
+		return "pong", nil
+	})
+	r.AddWorkflowN("Workflow", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("Ping").Await(nil); err != nil {
+			return nil, err
+		}
+		return "done", nil
+	})
+
+	iid := api.InstanceID("abc123")
+	oldEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Workflow",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(uuid.New().String()),
+					},
+				},
+			},
+		},
+		{
+			EventId:   0,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_TaskScheduled{
+				TaskScheduled: &protos.TaskScheduledEvent{Name: "Ping"},
+			},
+		},
+	}
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_TaskCompleted{
+				TaskCompleted: &protos.TaskCompletedEvent{
+					TaskScheduledId: 0,
+					Result:          wrapperspb.String(`"pong"`),
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionTerminated{
+				ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+					Input: wrapperspb.String(`"stop"`),
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, oldEvents, newEvents, backend.ExecuteOptions{})
+	require.NoError(t, err)
+	require.Len(t, results.Actions, 1, "Expected only the completion action")
+	complete := results.Actions[0].GetCompleteWorkflow()
+	require.NotNil(t, complete)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, complete.WorkflowStatus)
+	require.Equal(t, `"done"`, complete.Result.GetValue())
+}
+
+// Verifies that a terminate delivered while the workflow is suspended still produces
+// the termination action. Suspension buffers other events but must not swallow the
+// terminate, and the suspended state must not suppress the returned actions.
+func Test_Executor_TerminateWhileSuspended(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddWorkflowN("Workflow", func(ctx *task.WorkflowContext) (any, error) {
+		var value int
+		if err := ctx.WaitForSingleEvent("MyEvent", 5*time.Second).Await(&value); err != nil {
+			return nil, err
+		}
+		return value, nil
+	})
+
+	iid := api.InstanceID("abc123")
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Workflow",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(uuid.New().String()),
+					},
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionSuspended{
+				ExecutionSuspended: &protos.ExecutionSuspendedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionTerminated{
+				ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+					Input: wrapperspb.String(`"stop"`),
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, []*protos.HistoryEvent{}, newEvents, backend.ExecuteOptions{})
+	require.NoError(t, err)
+	require.Len(t, results.Actions, 2, "Expected the pending timer and the termination action")
+	require.NotNil(t, results.Actions[0].GetCreateTimer())
+	complete := results.Actions[1].GetCompleteWorkflow()
+	require.NotNil(t, complete)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, complete.WorkflowStatus)
+}
+
+// Verifies that the executor returns actions ordered by their sequence number rather
+// than in map iteration order.
+func Test_Executor_ActionsDeterministicOrder(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddActivityN("Ping", func(ctx task.ActivityContext) (any, error) {
+		return "pong", nil
+	})
+	r.AddWorkflowN("Workflow", func(ctx *task.WorkflowContext) (any, error) {
+		tasks := make([]task.Task, 0, 5)
+		for i := 0; i < 5; i++ {
+			tasks = append(tasks, ctx.CallActivity("Ping"))
+		}
+		for _, tk := range tasks {
+			if err := tk.Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	})
+
+	iid := api.InstanceID("abc123")
+	newEvents := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "Workflow",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  string(iid),
+						ExecutionId: wrapperspb.String(uuid.New().String()),
+					},
+				},
+			},
+		},
+	}
+
+	executor := task.NewTaskExecutor(r)
+	results, err := executor.ExecuteWorkflow(ctx, iid, []*protos.HistoryEvent{}, newEvents, backend.ExecuteOptions{})
+	require.NoError(t, err)
+	require.Len(t, results.Actions, 5)
+	for i, a := range results.Actions {
+		require.Equal(t, int32(i), a.Id, "Actions must be ordered by sequence number")
+		require.NotNil(t, a.GetScheduleTask())
+	}
+}

--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -340,3 +340,183 @@ func Test_StartAndStop(t *testing.T) {
 	require.Equal(t, first, tp.AbandonedWorkItems()[0])
 	require.Len(t, tp.CompletedWorkItems(), 0)
 }
+
+// Verifies that the runtime forces a workflow to TERMINATED when the batch contains an
+// ExecutionTerminated event but the executor (SDK) fails to return a completion action,
+// e.g. because the terminate was not the last event in the batch.
+func Test_TryProcessSingleWorkflowWorkItem_ForcesTerminateWhenExecutorIgnoresIt(t *testing.T) {
+	workflowID := "test123"
+	wi := &backend.WorkflowWorkItem{
+		InstanceID: api.InstanceID(workflowID),
+		NewEvents: []*protos.HistoryEvent{
+			{
+				EventId:   -1,
+				Timestamp: timestamppb.New(time.Now()),
+				EventType: &protos.HistoryEvent_ExecutionStarted{
+					ExecutionStarted: &protos.ExecutionStartedEvent{
+						Name: "MyOrch",
+						WorkflowInstance: &protos.WorkflowInstance{
+							InstanceId:  workflowID,
+							ExecutionId: wrapperspb.String(uuid.New().String()),
+						},
+					},
+				},
+			},
+			{
+				EventId:   -1,
+				Timestamp: timestamppb.New(time.Now()),
+				EventType: &protos.HistoryEvent_ExecutionTerminated{
+					ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+						Input: wrapperspb.String(`"reason"`),
+					},
+				},
+			},
+			{
+				EventId:   -1,
+				Timestamp: timestamppb.New(time.Now()),
+				EventType: &protos.HistoryEvent_TaskCompleted{
+					TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 0},
+				},
+			},
+		},
+		State: runtimestate.NewWorkflowRuntimeState(workflowID, nil, []*protos.HistoryEvent{}),
+	}
+
+	// The executor ignores the terminate and keeps the workflow running with a timer.
+	result := &protos.WorkflowResponse{
+		Actions: []*protos.WorkflowAction{
+			{
+				Id: 2,
+				WorkflowActionType: &protos.WorkflowAction_CreateTimer{
+					CreateTimer: &protos.CreateTimerAction{
+						FireAt: timestamppb.New(time.Now().Add(time.Second)),
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	completed := atomic.Bool{}
+	be := mocks.NewBackend(t)
+	be.EXPECT().NextWorkflowWorkItem(anyContext).Return(wi, nil).Once()
+	be.EXPECT().NextWorkflowWorkItem(anyContext).Return(nil, errors.New("")).Once().Run(func(mock.Arguments) {
+		cancel()
+	})
+	be.EXPECT().CompleteWorkflowWorkItem(anyContext, wi).RunAndReturn(func(ctx context.Context, owi *backend.WorkflowWorkItem) error {
+		completed.Store(true)
+		return nil
+	}).Once()
+
+	ex := mocks.NewExecutor(t)
+	ex.EXPECT().ExecuteWorkflow(anyContext, wi.InstanceID, wi.State.OldEvents, mock.Anything, mock.Anything).Return(result, nil).Once()
+
+	worker := backend.NewWorkflowWorker(backend.WorkflowWorkerOptions{
+		Backend:  be,
+		Executor: ex,
+		Logger:   logger,
+		AppID:    "testapp",
+	})
+	worker.Start(ctx)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.True(collect, completed.Load())
+	}, 1*time.Second, 100*time.Millisecond)
+
+	worker.StopAndDrain()
+
+	require.True(t, runtimestate.IsCompleted(wi.State))
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, runtimestate.RuntimeStatus(wi.State))
+	output, err := runtimestate.Output(wi.State)
+	require.NoError(t, err)
+	require.Equal(t, `"reason"`, output.GetValue())
+	require.Empty(t, wi.State.PendingTasks)
+	require.Empty(t, wi.State.PendingTimers)
+}
+
+// Verifies that a ContinueAsNew returned by the executor cannot override a terminate
+// present in the same batch: the runtime must not start a new generation and must
+// finish the instance as TERMINATED without re-invoking the executor.
+func Test_TryProcessSingleWorkflowWorkItem_TerminateBeatsContinueAsNewFromExecutor(t *testing.T) {
+	workflowID := "test123"
+	wi := &backend.WorkflowWorkItem{
+		InstanceID: api.InstanceID(workflowID),
+		NewEvents: []*protos.HistoryEvent{
+			{
+				EventId:   -1,
+				Timestamp: timestamppb.New(time.Now()),
+				EventType: &protos.HistoryEvent_ExecutionStarted{
+					ExecutionStarted: &protos.ExecutionStartedEvent{
+						Name: "MyOrch",
+						WorkflowInstance: &protos.WorkflowInstance{
+							InstanceId:  workflowID,
+							ExecutionId: wrapperspb.String(uuid.New().String()),
+						},
+					},
+				},
+			},
+			{
+				EventId:   -1,
+				Timestamp: timestamppb.New(time.Now()),
+				EventType: &protos.HistoryEvent_ExecutionTerminated{
+					ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+						Input: wrapperspb.String(`"reason"`),
+					},
+				},
+			},
+			{
+				EventId:   -1,
+				Timestamp: timestamppb.New(time.Now()),
+				EventType: &protos.HistoryEvent_TaskCompleted{
+					TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 0},
+				},
+			},
+		},
+		State: runtimestate.NewWorkflowRuntimeState(workflowID, nil, []*protos.HistoryEvent{}),
+	}
+
+	result := &protos.WorkflowResponse{
+		Actions: []*protos.WorkflowAction{
+			{
+				Id: 2,
+				WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+					CompleteWorkflow: &protos.CompleteWorkflowAction{
+						WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW,
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	completed := atomic.Bool{}
+	be := mocks.NewBackend(t)
+	be.EXPECT().NextWorkflowWorkItem(anyContext).Return(wi, nil).Once()
+	be.EXPECT().NextWorkflowWorkItem(anyContext).Return(nil, errors.New("")).Once().Run(func(mock.Arguments) {
+		cancel()
+	})
+	be.EXPECT().CompleteWorkflowWorkItem(anyContext, wi).RunAndReturn(func(ctx context.Context, owi *backend.WorkflowWorkItem) error {
+		completed.Store(true)
+		return nil
+	}).Once()
+
+	ex := mocks.NewExecutor(t)
+	ex.EXPECT().ExecuteWorkflow(anyContext, wi.InstanceID, mock.Anything, mock.Anything, mock.Anything).Return(result, nil).Once()
+
+	worker := backend.NewWorkflowWorker(backend.WorkflowWorkerOptions{
+		Backend:  be,
+		Executor: ex,
+		Logger:   logger,
+		AppID:    "testapp",
+	})
+	worker.Start(ctx)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.True(collect, completed.Load())
+	}, 1*time.Second, 100*time.Millisecond)
+
+	worker.StopAndDrain()
+
+	require.True(t, runtimestate.IsCompleted(wi.State))
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, runtimestate.RuntimeStatus(wi.State))
+}

--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -460,7 +460,8 @@ func Test_TryProcessSingleWorkflowWorkItem_TerminateBeatsContinueAsNewFromExecut
 				Timestamp: timestamppb.New(time.Now()),
 				EventType: &protos.HistoryEvent_ExecutionTerminated{
 					ExecutionTerminated: &protos.ExecutionTerminatedEvent{
-						Input: wrapperspb.String(`"reason"`),
+						Input:   wrapperspb.String(`"reason"`),
+						Recurse: true,
 					},
 				},
 			},
@@ -472,7 +473,34 @@ func Test_TryProcessSingleWorkflowWorkItem_TerminateBeatsContinueAsNewFromExecut
 				},
 			},
 		},
-		State: runtimestate.NewWorkflowRuntimeState(workflowID, nil, []*protos.HistoryEvent{}),
+		// The committed history already contains a child workflow: the
+		// terminate must cascade to it, which requires the ContinueAsNew wipe
+		// to never happen (the wipe would discard this event).
+		State: runtimestate.NewWorkflowRuntimeState(workflowID, nil, []*protos.HistoryEvent{
+			{
+				EventId:   -1,
+				Timestamp: timestamppb.New(time.Now()),
+				EventType: &protos.HistoryEvent_ExecutionStarted{
+					ExecutionStarted: &protos.ExecutionStartedEvent{
+						Name: "MyOrch",
+						WorkflowInstance: &protos.WorkflowInstance{
+							InstanceId:  workflowID,
+							ExecutionId: wrapperspb.String(uuid.New().String()),
+						},
+					},
+				},
+			},
+			{
+				EventId:   0,
+				Timestamp: timestamppb.New(time.Now()),
+				EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{
+					ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{
+						Name:       "MyChild",
+						InstanceId: "child1",
+					},
+				},
+			},
+		}),
 	}
 
 	result := &protos.WorkflowResponse{
@@ -519,4 +547,9 @@ func Test_TryProcessSingleWorkflowWorkItem_TerminateBeatsContinueAsNewFromExecut
 
 	require.True(t, runtimestate.IsCompleted(wi.State))
 	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, runtimestate.RuntimeStatus(wi.State))
+	require.False(t, wi.State.ContinuedAsNew, "the ContinueAsNew must not have started a new generation")
+	require.Len(t, wi.State.PendingMessages, 1, "the recursive terminate must cascade to the child")
+	cascade := wi.State.PendingMessages[0]
+	require.Equal(t, "child1", cascade.TargetInstanceId)
+	require.NotNil(t, cascade.HistoryEvent.GetExecutionTerminated())
 }


### PR DESCRIPTION
Terminating a workflow was silently dropped whenever the ExecutionTerminated event was not the last event in the work item it arrived in, e.g. [ExecutionTerminated, TaskCompleted]. The workflow stayed RUNNING forever and the terminate caller blocked indefinitely in WaitForInstanceCompletion. Because the event is consumed with the work item, the terminate could never be re-delivered and the instance was permanently unstoppable.

task: latch termination in onExecutionTerminated so no later event in the batch can resume the workflow function, mirroring the suspend latch. Return actions sorted by sequence number. The first completion of a batch wins, matching the cross work item behaviour where a completed workflow drops subsequent terminates, except that ContinueAsNew never overrides a terminate. actions() now emits the termination action even while suspended.

backend/runtimestate: skip completion actions, including ContinueAsNew, once the state already holds a completion, so a terminal state can neither be overridden nor wiped within one apply pass.

backend: enforce termination runtime side for any SDK. If a work item carried an ExecutionTerminated event and the executor did not complete the workflow, do not enter the ContinueAsNew loop; drop the doomed execution's pending tasks, timers and messages, and complete the instance as TERMINATED through the applier so the parent notification and cascade termination of child workflows still fire.