### PR TITLE
task: buffer resolution events that arrive before their work is scheduled

### DIFF
--- a/client/worker_grpc.go
+++ b/client/worker_grpc.go
@@ -51,7 +51,7 @@ func (c *TaskHubGrpcClient) startKeepaliveLoop(ctx context.Context) context.Canc
 }
 
 func (c *TaskHubGrpcClient) StartWorkItemListener(ctx context.Context, r *task.TaskRegistry) error {
-	executor := task.NewTaskExecutor(r)
+	executor := task.NewTaskExecutorWithLogger(r, c.logger)
 
 	var stream workItemsStream
 	// streamCancel cancels the context of the current GetWorkItems stream. It lets

--- a/task/executor.go
+++ b/task/executor.go
@@ -18,12 +18,23 @@ import (
 
 type taskExecutor struct {
 	Registry *TaskRegistry
+	logger   backend.Logger
 }
 
 // NewTaskExecutor returns a [backend.Executor] implementation that executes workflow and activity functions in-memory.
 func NewTaskExecutor(registry *TaskRegistry) backend.Executor {
+	return NewTaskExecutorWithLogger(registry, backend.DefaultLogger())
+}
+
+// NewTaskExecutorWithLogger is NewTaskExecutor with a caller-supplied logger
+// used for replay diagnostics.
+func NewTaskExecutorWithLogger(registry *TaskRegistry, logger backend.Logger) backend.Executor {
+	if logger == nil {
+		logger = backend.DefaultLogger()
+	}
 	return &taskExecutor{
 		Registry: registry,
+		logger:   logger,
 	}
 }
 
@@ -149,6 +160,7 @@ func (te *taskExecutor) ExecuteActivity(ctx context.Context, id api.InstanceID, 
 // ExecuteWorkflow implements backend.Executor and executes a workflow function in the current goroutine.
 func (te *taskExecutor) ExecuteWorkflow(ctx context.Context, id api.InstanceID, oldEvents []*protos.HistoryEvent, newEvents []*protos.HistoryEvent, opts backend.ExecuteOptions) (*protos.WorkflowResponse, error) {
 	workflowCtx := NewWorkflowContext(te.Registry, id, oldEvents, newEvents)
+	workflowCtx.SetLogger(te.logger)
 
 	if opts.PropagatedHistory != nil {
 		ph, err := api.PropagatedHistoryFromProto(opts.PropagatedHistory)

--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -17,8 +17,26 @@ import (
 	"github.com/dapr/durabletask-go/api/helpers"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/backend/runtimestate/dedup"
 	"github.com/dapr/kit/ptr"
 )
+
+// resolutionKey correlates a resolution event
+// (TaskCompleted/TaskFailed/TimerFired/ChildWorkflowInstance{Completed,Failed})
+// with the pending entry it resolves, using the same (kind, id) semantics as
+// backend/runtimestate/dedup.
+type resolutionKey struct {
+	kind dedup.Kind
+	id   int32
+}
+
+// bufferedResolution holds a resolution event that arrived before the
+// workflow scheduled the matching work in this execution, so it can be
+// delivered once the matching pending entry is registered.
+type bufferedResolution struct {
+	redeliver func() error
+	desc      string
+}
 
 // externalEventIndefiniteFireAt is the sentinel fire-at value used for the
 // synthetic timer backing WaitForExternalEvent calls with a negative
@@ -57,6 +75,10 @@ type WorkflowContext struct {
 	bufferedExternalEvents     map[string]*list.List
 	pendingExternalEventTasks  map[string]*list.List
 	saveBufferedExternalEvents bool
+	bufferedResolutions        map[resolutionKey]bufferedResolution
+	resolvedResolutions        map[resolutionKey]struct{}
+	suppressedActionIDs        map[int32]struct{}
+	logger                     backend.Logger
 	historyPatches             map[string]bool
 	appliedPatches             map[string]bool
 	encounteredPatches         []string
@@ -186,6 +208,17 @@ func NewWorkflowContext(registry *TaskRegistry, id api.InstanceID, oldEvents []*
 		historyPatches:            make(map[string]bool),
 		appliedPatches:            make(map[string]bool),
 		encounteredPatches:        make([]string, 0),
+		bufferedResolutions:       make(map[resolutionKey]bufferedResolution),
+		resolvedResolutions:       make(map[resolutionKey]struct{}),
+		suppressedActionIDs:       make(map[int32]struct{}),
+		logger:                    backend.DefaultLogger(),
+	}
+}
+
+// SetLogger sets the logger used for replay diagnostics on the context.
+func (octx *WorkflowContext) SetLogger(l backend.Logger) {
+	if l != nil {
+		octx.logger = l
 	}
 }
 
@@ -195,6 +228,13 @@ func (ctx *WorkflowContext) start() (actions []*protos.WorkflowAction) {
 	ctx.defaultDetachedWorkflowCounter = 0
 	ctx.pendingActions = make(map[int32]*protos.WorkflowAction)
 	ctx.pendingTasks = make(map[int32]*completableTask)
+	clear(ctx.bufferedResolutions)
+	clear(ctx.resolvedResolutions)
+	clear(ctx.suppressedActionIDs)
+
+	// Registered before the recover defer so it runs on both the normal exit
+	// and the ErrTaskBlocked path.
+	defer ctx.warnUnconsumedResolutions()
 
 	defer func() {
 		result := recover()
@@ -402,6 +442,7 @@ func (ctx *WorkflowContext) internalScheduleActivity(activityName, taskExecution
 
 	task := newTask(ctx)
 	ctx.pendingTasks[scheduleTaskAction.Id] = task
+	ctx.consumeBufferedResolution(dedup.KindTask, scheduleTaskAction.Id)
 	return task
 }
 
@@ -489,6 +530,7 @@ func (ctx *WorkflowContext) internalCallChildWorkflow(workflowName string, optio
 
 	task := newTask(ctx)
 	ctx.pendingTasks[createChildWorkflowAction.Id] = task
+	ctx.consumeBufferedResolution(dedup.KindChild, createChildWorkflowAction.Id)
 	return task
 }
 
@@ -581,6 +623,7 @@ func (ctx *WorkflowContext) createTimerInternal(name *string, delay time.Duratio
 
 	task := newTask(ctx)
 	ctx.pendingTasks[timerAction.Id] = task
+	ctx.consumeBufferedResolution(dedup.KindTimer, timerAction.Id)
 	return task, createTimer
 }
 
@@ -603,6 +646,7 @@ func (ctx *WorkflowContext) createExternalEventTimerInternal(eventName string, f
 
 	task := newTask(ctx)
 	ctx.pendingTasks[timerAction.Id] = task
+	ctx.consumeBufferedResolution(dedup.KindTimer, timerAction.Id)
 	return task
 }
 
@@ -770,16 +814,78 @@ func (ctx *WorkflowContext) onTaskScheduled(taskID int32, ts *protos.TaskSchedul
 	return nil
 }
 
+// bufferResolution records a resolution event that arrived before the
+// workflow scheduled the matching work in this execution, so it can be
+// delivered when the matching pending entry is registered. True duplicates
+// (the id was already resolved this execution, or an identical early
+// resolution is already buffered) are dropped; runtime state dedup upstream
+// makes those unreachable in practice, this is defense in depth.
+func (ctx *WorkflowContext) bufferResolution(key resolutionKey, eventName string, redeliver func() error) {
+	if _, resolved := ctx.resolvedResolutions[key]; resolved {
+		ctx.logger.Debugf("%v: dropping duplicate %s for id %d: already resolved this execution", ctx.ID, eventName, key.id)
+		return
+	}
+	if _, buffered := ctx.bufferedResolutions[key]; buffered {
+		ctx.logger.Debugf("%v: dropping duplicate %s for id %d: already buffered this execution", ctx.ID, eventName, key.id)
+		return
+	}
+	ctx.logger.Debugf("%v: buffering early %s for id %d until the workflow schedules the matching work", ctx.ID, eventName, key.id)
+	ctx.bufferedResolutions[key] = bufferedResolution{
+		redeliver: redeliver,
+		desc:      fmt.Sprintf("%s for id %d", eventName, key.id),
+	}
+}
+
+// consumeBufferedResolution delivers a buffered early resolution to the
+// pending entry that was just registered for (kind, id). The pending action
+// is left in place so a late scheduled event in history can still match it,
+// but it is suppressed from actions() so already resolved work is never
+// dispatched.
+func (ctx *WorkflowContext) consumeBufferedResolution(kind dedup.Kind, id int32) {
+	key := resolutionKey{kind: kind, id: id}
+	br, ok := ctx.bufferedResolutions[key]
+	if !ok {
+		return
+	}
+	delete(ctx.bufferedResolutions, key)
+	ctx.suppressedActionIDs[id] = struct{}{}
+	ctx.logger.Debugf("%v: delivering buffered %s to newly scheduled work; the action will not be dispatched", ctx.ID, br.desc)
+	// The handler cannot re-buffer on this path: the pending entry exists.
+	_ = br.redeliver()
+}
+
+// warnUnconsumedResolutions surfaces resolution events that were buffered
+// this execution but never matched any scheduled work.
+func (ctx *WorkflowContext) warnUnconsumedResolutions() {
+	if len(ctx.bufferedResolutions) == 0 {
+		return
+	}
+	keys := make([]resolutionKey, 0, len(ctx.bufferedResolutions))
+	for key := range ctx.bufferedResolutions {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].kind != keys[j].kind {
+			return keys[i].kind < keys[j].kind
+		}
+		return keys[i].id < keys[j].id
+	})
+	for _, key := range keys {
+		br := ctx.bufferedResolutions[key]
+		ctx.logger.Warnf("%v: %s arrived before the matching work was scheduled and was not consumed by the end of this execution; the event stays in history and is re-evaluated next turn, but if it never matches this indicates a non-deterministic workflow or an out-of-order history", ctx.ID, br.desc)
+	}
+}
+
 func (ctx *WorkflowContext) onTaskCompleted(tc *protos.TaskCompletedEvent) error {
 	taskID := tc.TaskScheduledId
+	key := resolutionKey{kind: dedup.KindTask, id: taskID}
 	task, ok := ctx.pendingTasks[taskID]
 	if !ok {
-		// TODO: This could be a duplicate event or it could be a non-deterministic workflow.
-		//       Duplicate events should be handled gracefully with a warning. Otherwise, the
-		//       workflow should probably fail with an error.
+		ctx.bufferResolution(key, "TaskCompleted", func() error { return ctx.onTaskCompleted(tc) })
 		return nil
 	}
 	delete(ctx.pendingTasks, taskID)
+	ctx.resolvedResolutions[key] = struct{}{}
 
 	if tc.Result != nil {
 		task.complete([]byte(tc.Result.Value))
@@ -791,14 +897,14 @@ func (ctx *WorkflowContext) onTaskCompleted(tc *protos.TaskCompletedEvent) error
 
 func (ctx *WorkflowContext) onTaskFailed(tf *protos.TaskFailedEvent) error {
 	taskID := tf.TaskScheduledId
+	key := resolutionKey{kind: dedup.KindTask, id: taskID}
 	task, ok := ctx.pendingTasks[taskID]
 	if !ok {
-		// TODO: This could be a duplicate event or it could be a non-deterministic workflow.
-		//       Duplicate events should be handled gracefully with a warning. Otherwise, the
-		//       workflow should probably fail with an error.
+		ctx.bufferResolution(key, "TaskFailed", func() error { return ctx.onTaskFailed(tf) })
 		return nil
 	}
 	delete(ctx.pendingTasks, taskID)
+	ctx.resolvedResolutions[key] = struct{}{}
 
 	// completing a task will resume the corresponding Await() call
 	task.fail(tf.FailureDetails)
@@ -826,14 +932,14 @@ func (ctx *WorkflowContext) onChildWorkflowScheduled(taskID int32, ts *protos.Ch
 
 func (ctx *WorkflowContext) onChildWorkflowCompleted(soc *protos.ChildWorkflowInstanceCompletedEvent) error {
 	taskID := soc.TaskScheduledId
+	key := resolutionKey{kind: dedup.KindChild, id: taskID}
 	task, ok := ctx.pendingTasks[taskID]
 	if !ok {
-		// TODO: This could be a duplicate event or it could be a non-deterministic workflow.
-		//       Duplicate events should be handled gracefully with a warning. Otherwise, the
-		//       workflow should probably fail with an error.
+		ctx.bufferResolution(key, "ChildWorkflowInstanceCompleted", func() error { return ctx.onChildWorkflowCompleted(soc) })
 		return nil
 	}
 	delete(ctx.pendingTasks, taskID)
+	ctx.resolvedResolutions[key] = struct{}{}
 
 	// completing a task will resume the corresponding Await() call
 	if soc.Result != nil {
@@ -846,14 +952,14 @@ func (ctx *WorkflowContext) onChildWorkflowCompleted(soc *protos.ChildWorkflowIn
 
 func (ctx *WorkflowContext) onChildWorkflowFailed(sof *protos.ChildWorkflowInstanceFailedEvent) error {
 	taskID := sof.TaskScheduledId
+	key := resolutionKey{kind: dedup.KindChild, id: taskID}
 	task, ok := ctx.pendingTasks[taskID]
 	if !ok {
-		// TODO: This could be a duplicate event or it could be a non-deterministic workflow.
-		//       Duplicate events should be handled gracefully with a warning. Otherwise, the
-		//       workflow should probably fail with an error.
+		ctx.bufferResolution(key, "ChildWorkflowInstanceFailed", func() error { return ctx.onChildWorkflowFailed(sof) })
 		return nil
 	}
 	delete(ctx.pendingTasks, taskID)
+	ctx.resolvedResolutions[key] = struct{}{}
 
 	// completing a task will resume the corresponding Await() call
 	task.fail(sof.FailureDetails)
@@ -883,14 +989,14 @@ func (ctx *WorkflowContext) onTimerCreated(e *protos.HistoryEvent) error {
 
 func (ctx *WorkflowContext) onTimerFired(tf *protos.TimerFiredEvent) error {
 	timerID := tf.TimerId
+	key := resolutionKey{kind: dedup.KindTimer, id: timerID}
 	task, ok := ctx.pendingTasks[timerID]
 	if !ok {
-		// TODO: This could be a duplicate event or it could be a non-deterministic workflow.
-		//       Duplicate events should be handled gracefully with a warning. Otherwise, the
-		//       workflow should probably fail with an error.
+		ctx.bufferResolution(key, "TimerFired", func() error { return ctx.onTimerFired(tf) })
 		return nil
 	}
 	delete(ctx.pendingTasks, timerID)
+	ctx.resolvedResolutions[key] = struct{}{}
 
 	// completing a task will resume the corresponding Await() call
 	task.complete(nil)
@@ -1121,6 +1227,23 @@ func (ctx *WorkflowContext) dropOptionalExternalEventTimerAt(atID int32) bool {
 		ctx.pendingTasks[id-1] = t
 	}
 
+	// Suppressed action ids track pendingActions entries, so they shift with
+	// them. bufferedResolutions keys are numbered by history events and must
+	// NOT be shifted: this drop exists precisely to align the current ids to
+	// the history numbering.
+	delete(ctx.suppressedActionIDs, atID)
+	suppressedIDs := make([]int32, 0, len(ctx.suppressedActionIDs))
+	for id := range ctx.suppressedActionIDs {
+		if id > atID {
+			suppressedIDs = append(suppressedIDs, id)
+		}
+	}
+	sort.Slice(suppressedIDs, func(i, j int) bool { return suppressedIDs[i] < suppressedIDs[j] })
+	for _, id := range suppressedIDs {
+		delete(ctx.suppressedActionIDs, id)
+		ctx.suppressedActionIDs[id-1] = struct{}{}
+	}
+
 	ctx.sequenceNumber--
 	return true
 }
@@ -1134,6 +1257,13 @@ func (ctx *WorkflowContext) actions() []*protos.WorkflowAction {
 
 	var actions []*protos.WorkflowAction
 	for _, a := range ctx.pendingActions {
+		// Actions whose resolution was already delivered from the buffered
+		// early resolutions are withheld: the work is resolved, so it must
+		// never be dispatched. The pending action itself is retained so a
+		// late scheduled event in history can still match it.
+		if _, ok := ctx.suppressedActionIDs[a.Id]; ok {
+			continue
+		}
 		// A terminated workflow must not start any new work: emit only the
 		// completion action and keep everything else withheld, in particular
 		// tasks and timers that suspension had suppressed before the

--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -441,6 +441,7 @@ func (ctx *WorkflowContext) internalScheduleActivity(activityName, taskExecution
 	ctx.pendingActions[scheduleTaskAction.Id] = scheduleTaskAction
 
 	task := newTask(ctx)
+	task.kind = dedup.KindTask
 	ctx.pendingTasks[scheduleTaskAction.Id] = task
 	ctx.consumeBufferedResolution(dedup.KindTask, scheduleTaskAction.Id)
 	return task
@@ -529,6 +530,7 @@ func (ctx *WorkflowContext) internalCallChildWorkflow(workflowName string, optio
 	ctx.pendingActions[createChildWorkflowAction.Id] = createChildWorkflowAction
 
 	task := newTask(ctx)
+	task.kind = dedup.KindChild
 	ctx.pendingTasks[createChildWorkflowAction.Id] = task
 	ctx.consumeBufferedResolution(dedup.KindChild, createChildWorkflowAction.Id)
 	return task
@@ -622,6 +624,7 @@ func (ctx *WorkflowContext) createTimerInternal(name *string, delay time.Duratio
 	ctx.pendingActions[timerAction.Id] = timerAction
 
 	task := newTask(ctx)
+	task.kind = dedup.KindTimer
 	ctx.pendingTasks[timerAction.Id] = task
 	ctx.consumeBufferedResolution(dedup.KindTimer, timerAction.Id)
 	return task, createTimer
@@ -645,6 +648,7 @@ func (ctx *WorkflowContext) createExternalEventTimerInternal(eventName string, f
 	ctx.pendingActions[timerAction.Id] = timerAction
 
 	task := newTask(ctx)
+	task.kind = dedup.KindTimer
 	ctx.pendingTasks[timerAction.Id] = task
 	ctx.consumeBufferedResolution(dedup.KindTimer, timerAction.Id)
 	return task
@@ -880,7 +884,7 @@ func (ctx *WorkflowContext) onTaskCompleted(tc *protos.TaskCompletedEvent) error
 	taskID := tc.TaskScheduledId
 	key := resolutionKey{kind: dedup.KindTask, id: taskID}
 	task, ok := ctx.pendingTasks[taskID]
-	if !ok {
+	if !ok || task.kind != dedup.KindTask {
 		ctx.bufferResolution(key, "TaskCompleted", func() error { return ctx.onTaskCompleted(tc) })
 		return nil
 	}
@@ -899,7 +903,7 @@ func (ctx *WorkflowContext) onTaskFailed(tf *protos.TaskFailedEvent) error {
 	taskID := tf.TaskScheduledId
 	key := resolutionKey{kind: dedup.KindTask, id: taskID}
 	task, ok := ctx.pendingTasks[taskID]
-	if !ok {
+	if !ok || task.kind != dedup.KindTask {
 		ctx.bufferResolution(key, "TaskFailed", func() error { return ctx.onTaskFailed(tf) })
 		return nil
 	}
@@ -934,7 +938,7 @@ func (ctx *WorkflowContext) onChildWorkflowCompleted(soc *protos.ChildWorkflowIn
 	taskID := soc.TaskScheduledId
 	key := resolutionKey{kind: dedup.KindChild, id: taskID}
 	task, ok := ctx.pendingTasks[taskID]
-	if !ok {
+	if !ok || task.kind != dedup.KindChild {
 		ctx.bufferResolution(key, "ChildWorkflowInstanceCompleted", func() error { return ctx.onChildWorkflowCompleted(soc) })
 		return nil
 	}
@@ -954,7 +958,7 @@ func (ctx *WorkflowContext) onChildWorkflowFailed(sof *protos.ChildWorkflowInsta
 	taskID := sof.TaskScheduledId
 	key := resolutionKey{kind: dedup.KindChild, id: taskID}
 	task, ok := ctx.pendingTasks[taskID]
-	if !ok {
+	if !ok || task.kind != dedup.KindChild {
 		ctx.bufferResolution(key, "ChildWorkflowInstanceFailed", func() error { return ctx.onChildWorkflowFailed(sof) })
 		return nil
 	}
@@ -991,7 +995,7 @@ func (ctx *WorkflowContext) onTimerFired(tf *protos.TimerFiredEvent) error {
 	timerID := tf.TimerId
 	key := resolutionKey{kind: dedup.KindTimer, id: timerID}
 	task, ok := ctx.pendingTasks[timerID]
-	if !ok {
+	if !ok || task.kind != dedup.KindTimer {
 		ctx.bufferResolution(key, "TimerFired", func() error { return ctx.onTimerFired(tf) })
 		return nil
 	}
@@ -1245,6 +1249,16 @@ func (ctx *WorkflowContext) dropOptionalExternalEventTimerAt(atID int32) bool {
 	}
 
 	ctx.sequenceNumber--
+
+	// The shift moved pending entries onto their history numbering, so a
+	// resolution buffered under a history id may now match a shifted entry;
+	// deliver any that do.
+	for _, id := range taskIDs {
+		newID := id - 1
+		if t, ok := ctx.pendingTasks[newID]; ok {
+			ctx.consumeBufferedResolution(t.kind, newID)
+		}
+	}
 	return true
 }
 

--- a/task/orchestrator_buffered_test.go
+++ b/task/orchestrator_buffered_test.go
@@ -1,0 +1,736 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+// captureLogger records formatted log lines per level for assertions.
+type captureLogger struct {
+	mu    sync.Mutex
+	warns []string
+	debug []string
+}
+
+func (c *captureLogger) log(dst *[]string, format string, v ...any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	*dst = append(*dst, fmt.Sprintf(format, v...))
+}
+
+func (c *captureLogger) Debug(v ...any)                 {}
+func (c *captureLogger) Debugf(format string, v ...any) { c.log(&c.debug, format, v...) }
+func (c *captureLogger) Info(v ...any)                  {}
+func (c *captureLogger) Infof(format string, v ...any)  {}
+func (c *captureLogger) Warn(v ...any)                  {}
+func (c *captureLogger) Warnf(format string, v ...any)  { c.log(&c.warns, format, v...) }
+func (c *captureLogger) Error(v ...any)                 {}
+func (c *captureLogger) Errorf(format string, v ...any) {}
+
+func (c *captureLogger) warnsContaining(sub string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, w := range c.warns {
+		if strings.Contains(w, sub) {
+			n++
+		}
+	}
+	return n
+}
+
+func evExecutionStarted(name string) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name:             name,
+				WorkflowInstance: &protos.WorkflowInstance{InstanceId: "buffered-test"},
+			},
+		},
+	}
+}
+
+func evTaskScheduled(id int32, name string) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   id,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskScheduled{
+			TaskScheduled: &protos.TaskScheduledEvent{Name: name},
+		},
+	}
+}
+
+func evTaskCompleted(id int32, result string) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: id,
+				Result:          wrapperspb.String(result),
+			},
+		},
+	}
+}
+
+func evTaskFailed(id int32, execID string) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskFailed{
+			TaskFailed: &protos.TaskFailedEvent{
+				TaskScheduledId: id,
+				TaskExecutionId: execID,
+				FailureDetails:  &protos.TaskFailureDetails{ErrorType: "TestError", ErrorMessage: "injected failure"},
+			},
+		},
+	}
+}
+
+func evTimerFired(id int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TimerFired{
+			TimerFired: &protos.TimerFiredEvent{TimerId: id, FireAt: timestamppb.Now()},
+		},
+	}
+}
+
+func evChildCompleted(id int32, result string) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId: id,
+				Result:          wrapperspb.String(result),
+			},
+		},
+	}
+}
+
+func evChildFailed(id int32) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceFailed{
+			ChildWorkflowInstanceFailed: &protos.ChildWorkflowInstanceFailedEvent{
+				TaskScheduledId: id,
+				FailureDetails:  &protos.TaskFailureDetails{ErrorType: "TestError", ErrorMessage: "injected child failure"},
+			},
+		},
+	}
+}
+
+func evEventRaised(name string) *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_EventRaised{
+			EventRaised: &protos.EventRaisedEvent{Name: name},
+		},
+	}
+}
+
+func evSuspended() *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionSuspended{
+			ExecutionSuspended: &protos.ExecutionSuspendedEvent{},
+		},
+	}
+}
+
+func evResumed() *protos.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionResumed{
+			ExecutionResumed: &protos.ExecutionResumedEvent{},
+		},
+	}
+}
+
+func runBuffered(t *testing.T, registry *TaskRegistry, oldEvents, newEvents []*protos.HistoryEvent) ([]*protos.WorkflowAction, *captureLogger) {
+	t.Helper()
+	cl := &captureLogger{}
+	ctx := NewWorkflowContext(registry, "buffered-test", oldEvents, newEvents)
+	ctx.SetLogger(cl)
+	return ctx.start(), cl
+}
+
+func completeAction(t *testing.T, actions []*protos.WorkflowAction) *protos.CompleteWorkflowAction {
+	t.Helper()
+	for _, a := range actions {
+		if co := a.GetCompleteWorkflow(); co != nil {
+			return co
+		}
+	}
+	return nil
+}
+
+func countActions(actions []*protos.WorkflowAction, pred func(*protos.WorkflowAction) bool) int {
+	n := 0
+	for _, a := range actions {
+		if pred(a) {
+			n++
+		}
+	}
+	return n
+}
+
+func isScheduleTask(a *protos.WorkflowAction) bool { return a.GetScheduleTask() != nil }
+func isCreateChild(a *protos.WorkflowAction) bool  { return a.GetCreateChildWorkflow() != nil }
+
+// waitThenActivityRegistry registers a workflow that waits for the "go" event
+// and then calls the "act" activity, returning the activity output. Sequence
+// numbers: the WaitForSingleEvent synthetic timer takes id 0, the activity
+// takes id 1.
+func waitThenActivityRegistry(t *testing.T) *TaskRegistry {
+	t.Helper()
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		var out string
+		if err := ctx.CallActivity("act").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, r.AddActivityN("act", func(ActivityContext) (any, error) { return "ran", nil }))
+	return r
+}
+
+func Test_BufferedResolution_EarlyTaskCompleted(t *testing.T) {
+	actions, cl := runBuffered(t, waitThenActivityRegistry(t), nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(1, `"injected"`),
+		evEventRaised("go"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co, "workflow must complete using the early completion")
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Equal(t, `"injected"`, co.GetResult().GetValue())
+	assert.Zero(t, countActions(actions, isScheduleTask), "the resolved activity must not be dispatched")
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_EarlyTaskFailed(t *testing.T) {
+	var gotExecID string
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		task := ctx.CallActivity("act")
+		err := task.Await(nil)
+		gotExecID = task.TaskExecutionId()
+		return nil, err
+	}))
+	require.NoError(t, r.AddActivityN("act", func(ActivityContext) (any, error) { return nil, nil }))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskFailed(1, "exec-x"),
+		evEventRaised("go"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED, co.WorkflowStatus)
+	assert.Contains(t, co.GetFailureDetails().GetErrorMessage(), "injected failure")
+	assert.Zero(t, countActions(actions, isScheduleTask))
+	assert.Equal(t, "exec-x", gotExecID)
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_EarlyTimerFired(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		if err := ctx.CreateTimer(time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		return "done", nil
+	}))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTimerFired(1),
+		evEventRaised("go"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Zero(t, countActions(actions, func(a *protos.WorkflowAction) bool {
+		return a.GetCreateTimer() != nil && a.Id == 1
+	}), "the resolved timer must not be dispatched")
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_EarlyChildCompleted(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		var out string
+		if err := ctx.CallChildWorkflow("child").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, r.AddWorkflowN("child", func(ctx *WorkflowContext) (any, error) { return "child-ran", nil }))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evChildCompleted(1, `"injected-child"`),
+		evEventRaised("go"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Equal(t, `"injected-child"`, co.GetResult().GetValue())
+	assert.Zero(t, countActions(actions, isCreateChild))
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_EarlyChildFailed(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, ctx.CallChildWorkflow("child").Await(nil)
+	}))
+	require.NoError(t, r.AddWorkflowN("child", func(ctx *WorkflowContext) (any, error) { return nil, nil }))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evChildFailed(1),
+		evEventRaised("go"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED, co.WorkflowStatus)
+	assert.Zero(t, countActions(actions, isCreateChild))
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_EarlyTimerFiredForExternalEventTimer(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("a", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		err := ctx.WaitForSingleEvent("b", time.Hour).Await(nil)
+		if errors.Is(err, ErrTaskCanceled) {
+			return "timedout", nil
+		}
+		return nil, err
+	}))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTimerFired(1),
+		evEventRaised("a"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co, "the buffered TimerFired must cancel the wait for event b immediately")
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Equal(t, `"timedout"`, co.GetResult().GetValue())
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_UnconsumedOrphanWarns(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		return nil, ctx.WaitForSingleEvent("go", -1).Await(nil)
+	}))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(99, `"orphan"`),
+		evEventRaised("go"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Equal(t, 1, cl.warnsContaining("TaskCompleted for id 99"))
+}
+
+func Test_BufferedResolution_UnconsumedOrphanWarnsOnBlockedTurn(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		return nil, ctx.WaitForSingleEvent("go", -1).Await(nil)
+	}))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(99, `"orphan"`),
+	})
+
+	assert.Nil(t, completeAction(t, actions), "workflow stays blocked on the external event")
+	assert.Equal(t, 1, cl.warnsContaining("TaskCompleted for id 99"))
+}
+
+func Test_BufferedResolution_DuplicateAfterResolutionDropped(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		var out string
+		if err := ctx.CallActivity("act").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, r.AddActivityN("act", func(ActivityContext) (any, error) { return nil, nil }))
+
+	actions, cl := runBuffered(t, r,
+		[]*protos.HistoryEvent{
+			evExecutionStarted("wf"),
+			evTaskScheduled(0, "act"),
+		},
+		[]*protos.HistoryEvent{
+			evTaskCompleted(0, `"first"`),
+			evTaskCompleted(0, `"second"`),
+		})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Equal(t, `"first"`, co.GetResult().GetValue(), "the first resolution wins; the duplicate is dropped")
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_LateTaskScheduledAfterDelivery(t *testing.T) {
+	// Histories produced by the pre-fix stall can contain the orphan
+	// completion followed by a late TaskScheduled for the same id. The
+	// retained pending action must match it without a nondeterminism error.
+	actions, cl := runBuffered(t, waitThenActivityRegistry(t), nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(1, `"injected"`),
+		evEventRaised("go"),
+		evTaskScheduled(1, "act"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Equal(t, `"injected"`, co.GetResult().GetValue())
+	assert.Zero(t, countActions(actions, isScheduleTask))
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_KindMismatchNotDelivered(t *testing.T) {
+	// A TimerFired for id 1 must not resolve the activity task at id 1: the
+	// activity is dispatched as before and the unmatched timer resolution
+	// warns at the end of the turn.
+	actions, cl := runBuffered(t, waitThenActivityRegistry(t), nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTimerFired(1),
+		evEventRaised("go"),
+	})
+
+	assert.Nil(t, completeAction(t, actions))
+	assert.Equal(t, 1, countActions(actions, isScheduleTask), "the activity dispatch is unaffected")
+	assert.Equal(t, 1, cl.warnsContaining("TimerFired for id 1"))
+}
+
+func Test_BufferedResolution_SuspensionPrecedence(t *testing.T) {
+	actions, cl := runBuffered(t, waitThenActivityRegistry(t), nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evSuspended(),
+		evTaskCompleted(1, `"injected"`),
+		evEventRaised("go"),
+		evResumed(),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Equal(t, `"injected"`, co.GetResult().GetValue())
+	assert.Zero(t, countActions(actions, isScheduleTask))
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_FreshContextPerExecution(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		return nil, ctx.WaitForSingleEvent("go", -1).Await(nil)
+	}))
+
+	_, cl1 := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(99, `"orphan"`),
+		evEventRaised("go"),
+	})
+	require.Equal(t, 1, cl1.warnsContaining("TaskCompleted for id 99"))
+
+	_, cl2 := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evEventRaised("go"),
+	})
+	assert.Empty(t, cl2.warns, "a fresh execution must not inherit buffered resolutions")
+}
+
+func Test_BufferedResolution_EarlyFailureWithRetryPolicy(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, ctx.CallActivity("act", WithActivityRetryPolicy(&RetryPolicy{
+			MaxAttempts:          3,
+			InitialRetryInterval: time.Second,
+			BackoffCoefficient:   2,
+		})).Await(nil)
+	}))
+	require.NoError(t, r.AddActivityN("act", func(ActivityContext) (any, error) { return nil, nil }))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskFailed(1, "exec-x"),
+		evEventRaised("go"),
+	})
+
+	// The buffered failure resolves attempt one at scheduling time and the
+	// retry wrapper immediately arms the backoff timer: the workflow blocks
+	// on the retry timer instead of completing, the failed attempt's
+	// ScheduleTask is suppressed, and the retry timer action is emitted.
+	assert.Nil(t, completeAction(t, actions))
+	assert.Zero(t, countActions(actions, isScheduleTask))
+	assert.Equal(t, 1, countActions(actions, func(a *protos.WorkflowAction) bool {
+		return a.GetCreateTimer() != nil && a.Id == 2
+	}), "the retry backoff timer must be armed")
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_FanOutTwoEarlyCompletions(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		t1 := ctx.CallActivity("a")
+		t2 := ctx.CallActivity("b")
+		var out1, out2 string
+		if err := t1.Await(&out1); err != nil {
+			return nil, err
+		}
+		if err := t2.Await(&out2); err != nil {
+			return nil, err
+		}
+		return out1 + out2, nil
+	}))
+	require.NoError(t, r.AddActivityN("a", func(ActivityContext) (any, error) { return nil, nil }))
+	require.NoError(t, r.AddActivityN("b", func(ActivityContext) (any, error) { return nil, nil }))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(2, `"two"`),
+		evTaskCompleted(1, `"one"`),
+		evEventRaised("go"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Equal(t, `"onetwo"`, co.GetResult().GetValue())
+	assert.Zero(t, countActions(actions, isScheduleTask))
+	assert.Empty(t, cl.warns)
+}
+
+func Test_BufferedResolution_TerminatedTurnEmitsOnlyCompletion(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		return nil, ctx.WaitForSingleEvent("go", -1).Await(nil)
+	}))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(7, `"orphan"`),
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionTerminated{
+				ExecutionTerminated: &protos.ExecutionTerminatedEvent{Input: wrapperspb.String(`"stop"`)},
+			},
+		},
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, co.WorkflowStatus)
+	for _, a := range actions {
+		assert.NotNil(t, a.GetCompleteWorkflow(), "a terminated turn must emit only the completion action")
+	}
+	assert.Equal(t, 1, cl.warnsContaining("TaskCompleted for id 7"))
+}
+
+func Test_BufferedResolution_ContinueAsNewNoCarryover(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		ctx.ContinueAsNew(nil, WithKeepUnprocessedEvents())
+		return nil, nil
+	}))
+
+	actions, cl := runBuffered(t, r, nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(5, `"orphan"`),
+		evEventRaised("go"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW, co.WorkflowStatus)
+	for _, e := range co.GetCarryoverEvents() {
+		assert.Nil(t, e.GetTaskCompleted(), "buffered resolutions must not be carried into the next generation")
+	}
+	assert.Equal(t, 1, cl.warnsContaining("TaskCompleted for id 5"))
+}
+
+func Test_BufferedResolution_ExecutorSurfacesWarning(t *testing.T) {
+	r := NewTaskRegistry()
+	require.NoError(t, r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		var out string
+		if err := ctx.CallActivity("act").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, r.AddActivityN("act", func(ActivityContext) (any, error) { return nil, nil }))
+
+	cl := &captureLogger{}
+	ex := NewTaskExecutorWithLogger(r, cl)
+
+	resp, err := ex.ExecuteWorkflow(t.Context(), "exec-test", nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(1, `"injected"`),
+		evEventRaised("go"),
+	}, backend.ExecuteOptions{})
+	require.NoError(t, err)
+	for _, a := range resp.GetActions() {
+		assert.Nil(t, a.GetScheduleTask(), "the suppressed action must not reach the backend response")
+	}
+	assert.Empty(t, cl.warns)
+
+	_, err = ex.ExecuteWorkflow(t.Context(), "exec-test", nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(42, `"orphan"`),
+		evEventRaised("go"),
+	}, backend.ExecuteOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, cl.warnsContaining("TaskCompleted for id 42"))
+}
+
+func Test_BufferedResolution_DropShiftsSuppressedIDs(t *testing.T) {
+	ctx := newTestContext(t)
+	ctx.suppressedActionIDs = map[int32]struct{}{2: {}, 3: {}}
+	ctx.pendingActions[1] = &protos.WorkflowAction{
+		Id: 1,
+		WorkflowActionType: &protos.WorkflowAction_CreateTimer{
+			CreateTimer: &protos.CreateTimerAction{
+				FireAt: timestamppb.New(externalEventIndefiniteFireAt),
+				Origin: &protos.CreateTimerAction_ExternalEvent{
+					ExternalEvent: &protos.TimerOriginExternalEvent{Name: "e"},
+				},
+			},
+		},
+	}
+	ctx.pendingActions[2] = &protos.WorkflowAction{Id: 2}
+	ctx.pendingActions[3] = &protos.WorkflowAction{Id: 3}
+	ctx.sequenceNumber = 4
+
+	require.True(t, ctx.dropOptionalExternalEventTimerAt(1))
+
+	assert.Equal(t, map[int32]struct{}{1: {}, 2: {}}, ctx.suppressedActionIDs,
+		"suppressed ids above the dropped id must shift down with their actions")
+}
+
+func Test_CompletableTask_OnCompletedAfterCompletion(t *testing.T) {
+	task := newTask(newTestContext(t))
+	task.complete([]byte("x"))
+	fired := false
+	task.onCompleted(func() { fired = true })
+	assert.True(t, fired, "onCompleted on an already completed task must fire immediately")
+}
+
+// Benchmark_ReplaySequentialActivities measures a full replay of a workflow
+// with 50 sequential completed activities, the shape dominated by the
+// per-event and per-schedule bookkeeping this file's feature adds to.
+func Benchmark_ReplaySequentialActivities(b *testing.B) {
+	const n = 50
+	r := NewTaskRegistry()
+	if err := r.AddWorkflowN("wf", func(ctx *WorkflowContext) (any, error) {
+		for range n {
+			if err := ctx.CallActivity("act").Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return "done", nil
+	}); err != nil {
+		b.Fatal(err)
+	}
+	if err := r.AddActivityN("act", func(ActivityContext) (any, error) { return nil, nil }); err != nil {
+		b.Fatal(err)
+	}
+
+	events := make([]*protos.HistoryEvent, 0, 2*n+1)
+	events = append(events, evExecutionStarted("wf"))
+	for i := range int32(n) {
+		events = append(events, evTaskScheduled(i, "act"), evTaskCompleted(i, `null`))
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ctx := NewWorkflowContext(r, "bench", events, nil)
+		if actions := ctx.start(); len(actions) != 1 {
+			b.Fatalf("expected 1 action, got %d", len(actions))
+		}
+	}
+}

--- a/task/orchestrator_buffered_test.go
+++ b/task/orchestrator_buffered_test.go
@@ -734,3 +734,42 @@ func Benchmark_ReplaySequentialActivities(b *testing.B) {
 		}
 	}
 }
+
+func Test_BufferedResolution_KindGuardOnOccupiedID(t *testing.T) {
+	// A TaskCompleted whose id is occupied by a pending TIMER (here the
+	// synthetic external event timer at id 0) must buffer rather than
+	// complete the timer, which would wrongly cancel the external event wait.
+	actions, cl := runBuffered(t, waitThenActivityRegistry(t), nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(0, `"x"`),
+		evEventRaised("go"),
+	})
+
+	assert.Nil(t, completeAction(t, actions),
+		"the wait must complete via the event, not fail via a wrongly cancelled timer")
+	assert.Equal(t, 1, countActions(actions, isScheduleTask),
+		"the activity dispatch proceeds normally")
+	assert.Equal(t, 1, cl.warnsContaining("TaskCompleted for id 0"))
+}
+
+func Test_BufferedResolution_PreSyntheticTimerMigration(t *testing.T) {
+	// A history produced before WaitForSingleEvent emitted its synthetic
+	// timer numbers the activity as id 0, which the current replay assigns
+	// to the synthetic timer. The early completion for id 0 must buffer past
+	// the timer (kind mismatch), and when the historical TaskScheduled(0)
+	// drops the optional timer and shifts the activity onto id 0, the
+	// buffered completion must be delivered to it.
+	actions, cl := runBuffered(t, waitThenActivityRegistry(t), nil, []*protos.HistoryEvent{
+		evExecutionStarted("wf"),
+		evTaskCompleted(0, `"migrated"`),
+		evEventRaised("go"),
+		evTaskScheduled(0, "act"),
+	})
+
+	co := completeAction(t, actions)
+	require.NotNil(t, co)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, co.WorkflowStatus)
+	assert.Equal(t, `"migrated"`, co.GetResult().GetValue())
+	assert.Zero(t, countActions(actions, isScheduleTask))
+	assert.Empty(t, cl.warns)
+}

--- a/task/task.go
+++ b/task/task.go
@@ -82,6 +82,13 @@ func (t *completableTask) TaskExecutionId() string {
 }
 
 func (t *completableTask) onCompleted(callback func()) {
+	// A task can already be completed at registration time when a buffered
+	// early resolution was delivered as the task was scheduled; fire the
+	// callback immediately so completion side effects are not lost.
+	if t.isCompleted {
+		callback()
+		return
+	}
 	t.completedCallback = callback
 }
 

--- a/task/task.go
+++ b/task/task.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/runtimestate/dedup"
 )
 
 // ErrTaskBlocked is not an error, but rather a control flow signal indicating that a workflow
@@ -30,6 +31,12 @@ type completableTask struct {
 	failureDetails    *protos.TaskFailureDetails
 	completedCallback func()
 	taskExecutionId   string
+	// kind is the resolution correlator family this task belongs to when it
+	// is registered in pendingTasks (task, timer or child). A resolution
+	// event only completes a pending entry of its own kind; anything else is
+	// buffered. Zero (KindNone) for tasks never held in pendingTasks, such
+	// as external event wait tasks.
+	kind dedup.Kind
 }
 
 func newTask(ctx *WorkflowContext) *completableTask {


### PR DESCRIPTION
A TaskCompleted, TaskFailed, TimerFired or ChildWorkflowInstance completion event that reached the replay before the workflow code had registered the matching pending entry was silently discarded. Because the event is consumed with its work item and later duplicates are dropped by runtime state dedup, the resolution was lost forever while the un-deleted pending action re-emitted its ScheduleTask. Backends which suppress dispatch when a resolution is already present in the state (such as dapr's actor backend) then deadlocked the workflow permanently, with no retry path and no warning. The known production trigger is a scheduler crash mid-workflow in dapr's clustered deployment mode, where redelivery races persist the completion of an aborted turn's activity dispatch into a history whose TaskScheduled was rolled back.

Mirror the existing bufferedExternalEvents mechanism: an unmatched resolution is buffered keyed by (kind, id) using the runtimestate dedup correlator, and delivered when the matching pending entry is registered later in the same replay. The pending action is retained so a late scheduled event in an already-persisted history still matches it, meaning histories stalled by the old behaviour recover on upgrade instead of failing with a nondeterminism error, but the action is suppressed from the returned actions so already-resolved work is never dispatched. Suppressed ids shift with their pending actions in dropOptionalExternalEventTimerAt; buffered resolutions are keyed by history numbering and deliberately do not shift. Resolutions still unconsumed at the end of the turn now log a warning, resolving the five long-standing TODOs in the handlers.