### PR TITLE
perf(executor): pipeline work item stream sends, prefer warm owner

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -27,6 +27,12 @@ var emptyCompleteTaskResponse = &protos.CompleteTaskResponse{}
 
 var errShuttingDown error = status.Error(codes.Canceled, "shutting down")
 
+// streamOutboxSize bounds how many dispatched work items may queue behind a
+// stream's in-flight Send before the dispatch loop blocks. It only needs to
+// cover the dispatch-to-wire gap of one stream; backpressure past it lands on
+// ss.ch and the shared queue as before.
+const streamOutboxSize = 64
+
 type pendingWorkflow struct {
 	instanceID api.InstanceID
 	streamID   string
@@ -594,15 +600,43 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 		}
 	}()
 
-	ch := make(chan *protos.WorkItem)
-	errCh := make(chan error, 1)
+	// One writer goroutine per stream keeps gRPC's one-Send-at-a-time rule
+	// while the dispatch loop below hands items off without waiting for the
+	// send to drain (the outbox bounds how far dispatch runs ahead of the
+	// wire). Per-instance ordering is enforced upstream by the actor turn
+	// lock (at most one in-flight turn per instance), and the single writer
+	// preserves FIFO within the stream regardless. A failed or timed-out
+	// send surfaces on sendFailed, tearing the stream down so the disconnect
+	// cleanup above recovers every pending item stamped with this stream,
+	// exactly as the synchronous send path did.
+	outCh := make(chan *protos.WorkItem, streamOutboxSize)
+	sendFailed := make(chan error, 1)
 	go func() {
 		for {
 			select {
 			case <-stream.Context().Done():
 				return
-			case wi := <-ch:
-				errCh <- stream.Send(wi)
+			case wi := <-outCh:
+				var timer *time.Timer
+				if g.streamSendTimeout != nil {
+					timer = time.AfterFunc(*g.streamSendTimeout, func() {
+						select {
+						case sendFailed <- errors.New("timed out while sending work item"):
+						default:
+						}
+					})
+				}
+				err := stream.Send(wi)
+				if timer != nil {
+					timer.Stop()
+				}
+				if err != nil {
+					select {
+					case sendFailed <- err:
+					default:
+					}
+					return
+				}
 			}
 		}
 	}()
@@ -611,19 +645,34 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 	// Items reach this stream either by affinity (its own ss.ch) or off the shared queue
 	// (work not pinned to a warm stream, plus all activities).
 	for {
+		// Drain affinity items first: the select below picks randomly among
+		// ready cases, which would let the shared queue starve a warm turn
+		// parked on ss.ch into spilling to a full-history resend elsewhere.
+		select {
+		case wi := <-ss.ch:
+			if err := g.dispatchToStream(stream, streamID, ss, wi, outCh, sendFailed); err != nil {
+				return err
+			}
+			continue
+		default:
+		}
+
 		select {
 		case <-stream.Context().Done():
 			g.logger.Info("work item stream closed")
 			return nil
+		case err := <-sendFailed:
+			g.logger.Errorf("encountered an error while sending work item: %v", err)
+			return err
 		case wi := <-ss.ch:
-			if err := g.dispatchToStream(stream, streamID, ss, wi, ch, errCh); err != nil {
+			if err := g.dispatchToStream(stream, streamID, ss, wi, outCh, sendFailed); err != nil {
 				return err
 			}
 		case wi, ok := <-g.workItemQueue:
 			if !ok {
 				continue
 			}
-			if err := g.dispatchToStream(stream, streamID, ss, wi, ch, errCh); err != nil {
+			if err := g.dispatchToStream(stream, streamID, ss, wi, outCh, sendFailed); err != nil {
 				return err
 			}
 		case <-g.streamShutdownChan:
@@ -642,8 +691,8 @@ func (g *grpcExecutor) dispatchToStream(
 	streamID string,
 	ss *streamState,
 	wi *protos.WorkItem,
-	ch chan *protos.WorkItem,
-	errCh chan error,
+	outCh chan *protos.WorkItem,
+	sendFailed chan error,
 ) error {
 	switch x := wi.Request.(type) {
 	case *protos.WorkItem_WorkflowRequest:
@@ -665,35 +714,26 @@ func (g *grpcExecutor) dispatchToStream(
 		}
 	}
 
-	if err := g.sendWorkItem(stream, wi, ch, errCh); err != nil {
+	if err := g.sendWorkItem(stream, wi, outCh, sendFailed); err != nil {
 		g.logger.Errorf("encountered an error while sending work item: %v", err)
 		return err
 	}
 	return nil
 }
 
+// sendWorkItem hands the work item to the stream's writer goroutine and
+// returns once it is queued: sends are pipelined, so dispatch does not
+// rendezvous with the wire.
 func (g *grpcExecutor) sendWorkItem(stream protos.TaskHubSidecarService_GetWorkItemsServer, wi *protos.WorkItem,
-	ch chan *protos.WorkItem, errCh chan error,
+	outCh chan *protos.WorkItem, sendFailed chan error,
 ) error {
 	select {
 	case <-stream.Context().Done():
 		return stream.Context().Err()
-	case ch <- wi:
-	}
-
-	ctx := stream.Context()
-	if g.streamSendTimeout != nil {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, *g.streamSendTimeout)
-		defer cancel()
-	}
-
-	select {
-	case <-ctx.Done():
-		g.logger.Errorf("timed out while sending work item")
-		return fmt.Errorf("timed out while sending work item: %w", ctx.Err())
-	case err := <-errCh:
+	case err := <-sendFailed:
 		return err
+	case outCh <- wi:
+		return nil
 	}
 }
 

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -645,15 +645,17 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 	// Items reach this stream either by affinity (its own ss.ch) or off the shared queue
 	// (work not pinned to a warm stream, plus all activities).
 	for {
-		// Drain affinity items first: the select below picks randomly among
-		// ready cases, which would let the shared queue starve a warm turn
-		// parked on ss.ch into spilling to a full-history resend elsewhere.
+		// Prefer one affinity item per pass: the select below picks randomly
+		// among ready cases, which would let the shared queue starve a warm
+		// turn parked on ss.ch into spilling to a full-history resend
+		// elsewhere. One item, not a full drain: an unbounded drain would let
+		// sustained affinity traffic monopolize the loop and starve the
+		// shared queue, which is the only path activities travel.
 		select {
 		case wi := <-ss.ch:
 			if err := g.dispatchToStream(stream, streamID, ss, wi, outCh, sendFailed); err != nil {
 				return err
 			}
-			continue
 		default:
 		}
 

--- a/backend/executor_stateful.go
+++ b/backend/executor_stateful.go
@@ -3,10 +3,17 @@ package backend
 import (
 	"context"
 	"hash/fnv"
+	"time"
 
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
 )
+
+// affinityOwnerGrace is how long a workflow item waits for its warm owner
+// stream before any free stream may take it. Sends are pipelined, so the
+// owner is only slow when its whole outbox is full; a short grace keeps the
+// turn a delta send instead of a full-history resend on a cold stream.
+const affinityOwnerGrace = 2 * time.Millisecond
 
 // maxWarmInstancesPerStream bounds the number of warm (stateful-history) instance
 // entries tracked per work-item stream. Evicting an entry only costs a single
@@ -81,8 +88,20 @@ func (g *grpcExecutor) dispatchWorkflowWorkItem(ctx context.Context, iid api.Ins
 			return nil
 		default:
 		}
-		// Owner busy: give it first crack but let any free stream take over so a
-		// slow or overloaded owner never stalls the instance.
+		// Owner busy: give it a short grace to drain before racing the shared
+		// queue, so a momentarily busy owner keeps the delta send. After the
+		// grace any free stream may take over, preserving the guarantee that
+		// the producer never blocks solely on the owner.
+		t := time.NewTimer(affinityOwnerGrace)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return ctx.Err()
+		case owner.ch <- wi:
+			t.Stop()
+			return nil
+		case <-t.C:
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/backend/executor_stream_test.go
+++ b/backend/executor_stream_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+// fakeExecBackend implements just enough of Backend to drive the executor's
+// GetWorkItems streams: completion waiters keyed by instance ID and a record
+// of cancelled workflow tasks (the stream-teardown recovery path).
+type fakeExecBackend struct {
+	Backend
+	mu       sync.Mutex
+	waiters  map[string]chan *protos.WorkflowResponse
+	canceled []api.InstanceID
+}
+
+func newFakeExecBackend() *fakeExecBackend {
+	return &fakeExecBackend{waiters: make(map[string]chan *protos.WorkflowResponse)}
+}
+
+func (f *fakeExecBackend) WaitForWorkflowTaskCompletion(req *protos.WorkflowRequest) func(context.Context) (*protos.WorkflowResponse, error) {
+	ch := make(chan *protos.WorkflowResponse, 1)
+	f.mu.Lock()
+	f.waiters[req.GetInstanceId()] = ch
+	f.mu.Unlock()
+	return func(ctx context.Context) (*protos.WorkflowResponse, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case resp := <-ch:
+			if resp == nil {
+				return nil, api.ErrTaskCancelled
+			}
+			return resp, nil
+		}
+	}
+}
+
+func (f *fakeExecBackend) complete(iid string) {
+	f.mu.Lock()
+	ch := f.waiters[iid]
+	f.mu.Unlock()
+	if ch != nil {
+		select {
+		case ch <- &protos.WorkflowResponse{InstanceId: iid}:
+		default:
+		}
+	}
+}
+
+func (f *fakeExecBackend) CancelWorkflowTask(_ context.Context, iid api.InstanceID) error {
+	f.mu.Lock()
+	f.canceled = append(f.canceled, iid)
+	ch := f.waiters[string(iid)]
+	f.mu.Unlock()
+	if ch != nil {
+		select {
+		case ch <- nil:
+		default:
+		}
+	}
+	return nil
+}
+
+func (f *fakeExecBackend) CancelActivityTask(context.Context, api.InstanceID, int32) error {
+	return nil
+}
+
+func (f *fakeExecBackend) canceledInstances() []api.InstanceID {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]api.InstanceID(nil), f.canceled...)
+}
+
+// fakeWorkItemsStream is a controllable GetWorkItems server stream: Send is
+// delegated to the test.
+type fakeWorkItemsStream struct {
+	grpc.ServerStream
+	ctx  context.Context
+	send func(*protos.WorkItem) error
+}
+
+func (f *fakeWorkItemsStream) Context() context.Context      { return f.ctx }
+func (f *fakeWorkItemsStream) Send(wi *protos.WorkItem) error { return f.send(wi) }
+
+func statefulWorkItemsRequest() *protos.GetWorkItemsRequest {
+	return &protos.GetWorkItemsRequest{
+		Capabilities: []protos.WorkerCapability{protos.WorkerCapability_WORKER_CAPABILITY_STATEFUL_HISTORY},
+	}
+}
+
+// TestGetWorkItems_PerInstanceOrderAcrossStreams runs N instances x M turns
+// through a few streams, with a recording handler completing each turn, and
+// asserts every instance observed its turns in order. Turn k+1 is only
+// dispatched after turn k completes, mirroring the actor turn lock upstream.
+func TestGetWorkItems_PerInstanceOrderAcrossStreams(t *testing.T) {
+	fb := newFakeExecBackend()
+	exec, _ := NewGrpcExecutor(fb, defaultLogger)
+	g, ok := exec.(*grpcExecutor)
+	require.True(t, ok)
+
+	var recMu sync.Mutex
+	received := map[string][]int32{}
+
+	streamCtx, streamCancel := context.WithCancel(t.Context())
+	defer streamCancel()
+
+	var wg sync.WaitGroup
+	const numStreams = 3
+	for range numStreams {
+		stream := &fakeWorkItemsStream{
+			ctx: streamCtx,
+			send: func(wi *protos.WorkItem) error {
+				req := wi.GetWorkflowRequest()
+				iid := req.GetInstanceId()
+				recMu.Lock()
+				received[iid] = append(received[iid], req.GetNewEvents()[0].GetEventId())
+				recMu.Unlock()
+				fb.complete(iid)
+				return nil
+			},
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, g.GetWorkItems(statefulWorkItemsRequest(), stream))
+		}()
+	}
+
+	const numInstances, numTurns = 8, 10
+	var iwg sync.WaitGroup
+	for i := range numInstances {
+		iwg.Add(1)
+		go func() {
+			defer iwg.Done()
+			iid := api.InstanceID(fmt.Sprintf("instance-%d", i))
+			for turn := range int32(numTurns) {
+				_, err := g.ExecuteWorkflow(t.Context(), iid, nil,
+					[]*protos.HistoryEvent{{EventId: turn}}, ExecuteOptions{})
+				assert.NoError(t, err)
+			}
+		}()
+	}
+	iwg.Wait()
+
+	recMu.Lock()
+	defer recMu.Unlock()
+	require.Len(t, received, numInstances)
+	for iid, turns := range received {
+		require.Len(t, turns, numTurns, "instance %s", iid)
+		for turn := range int32(numTurns) {
+			assert.Equal(t, turn, turns[turn], "instance %s out of order", iid)
+		}
+	}
+
+	streamCancel()
+	wg.Wait()
+}
+
+// TestGetWorkItems_SendFailureRecoversWorkItem asserts a failed Send still
+// tears the stream down and cancels the affected pending work item through
+// the backend (the abandon/retry path), instead of dropping it.
+func TestGetWorkItems_SendFailureRecoversWorkItem(t *testing.T) {
+	fb := newFakeExecBackend()
+	exec, _ := NewGrpcExecutor(fb, defaultLogger)
+	g, ok := exec.(*grpcExecutor)
+	require.True(t, ok)
+
+	sendErr := errors.New("send exploded mid-stream")
+	stream := &fakeWorkItemsStream{
+		ctx:  t.Context(),
+		send: func(*protos.WorkItem) error { return sendErr },
+	}
+
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- g.GetWorkItems(statefulWorkItemsRequest(), stream)
+	}()
+
+	execDone := make(chan error, 1)
+	go func() {
+		_, err := g.ExecuteWorkflow(t.Context(), "doomed", nil,
+			[]*protos.HistoryEvent{{EventId: 0}}, ExecuteOptions{})
+		execDone <- err
+	}()
+
+	select {
+	case err := <-streamDone:
+		require.ErrorIs(t, err, sendErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetWorkItems did not return after send failure")
+	}
+
+	select {
+	case err := <-execDone:
+		require.EqualError(t, err, "operation aborted")
+	case <-time.After(5 * time.Second):
+		t.Fatal("ExecuteWorkflow did not return after send failure")
+	}
+
+	assert.Equal(t, []api.InstanceID{"doomed"}, fb.canceledInstances())
+}
+
+// TestGetWorkItems_DispatchNotBlockedDuringSlowSend asserts the dispatch loop
+// keeps draining the shared queue while a Send is in flight: many small items
+// enqueued behind one slow send are all accepted before that send completes,
+// i.e. there is no per-item rendezvous.
+func TestGetWorkItems_DispatchNotBlockedDuringSlowSend(t *testing.T) {
+	fb := newFakeExecBackend()
+	exec, _ := NewGrpcExecutor(fb, defaultLogger)
+	g, ok := exec.(*grpcExecutor)
+	require.True(t, ok)
+
+	gate := make(chan struct{})
+	var sendMu sync.Mutex
+	var sent int
+	stream := &fakeWorkItemsStream{
+		ctx: t.Context(),
+		send: func(*protos.WorkItem) error {
+			sendMu.Lock()
+			sent++
+			first := sent == 1
+			sendMu.Unlock()
+			if first {
+				<-gate
+			}
+			return nil
+		},
+	}
+
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- g.GetWorkItems(&protos.GetWorkItemsRequest{}, stream)
+	}()
+
+	const numItems = 32
+	for i := range numItems {
+		g.workItemQueue <- &protos.WorkItem{
+			Request: &protos.WorkItem_WorkflowRequest{
+				WorkflowRequest: &protos.WorkflowRequest{InstanceId: fmt.Sprintf("wi-%d", i)},
+			},
+		}
+	}
+
+	// The first send is parked on the gate; with pipelining the dispatch loop
+	// still drains everything into the stream's outbox.
+	require.Eventually(t, func() bool {
+		return len(g.workItemQueue) == 0
+	}, 5*time.Second, 5*time.Millisecond, "dispatch loop rendezvoused with the in-flight send")
+
+	sendMu.Lock()
+	assert.Equal(t, 1, sent, "only the gated send should have started")
+	sendMu.Unlock()
+
+	close(gate)
+	require.Eventually(t, func() bool {
+		sendMu.Lock()
+		defer sendMu.Unlock()
+		return sent == numItems
+	}, 5*time.Second, 5*time.Millisecond)
+}
+
+// TestDispatchWorkflowWorkItem_OwnerBusyFallsBackAfterGrace asserts the
+// warm-owner preference never stalls dispatch: with the owner's affinity
+// buffer full and no stream draining it, the item falls back to the shared
+// queue after the grace.
+func TestDispatchWorkflowWorkItem_OwnerBusyFallsBackAfterGrace(t *testing.T) {
+	fb := newFakeExecBackend()
+	exec, _ := NewGrpcExecutor(fb, defaultLogger)
+	g, ok := exec.(*grpcExecutor)
+	require.True(t, ok)
+
+	ss := newStreamState("s1", statefulWorkItemsRequest())
+	for range cap(ss.ch) {
+		ss.ch <- &protos.WorkItem{}
+	}
+	g.streams.Store(ss.id, ss)
+
+	wi := &protos.WorkItem{
+		Request: &protos.WorkItem_WorkflowRequest{
+			WorkflowRequest: &protos.WorkflowRequest{InstanceId: "stuck-owner"},
+		},
+	}
+	require.NoError(t, g.dispatchWorkflowWorkItem(t.Context(), "stuck-owner", wi))
+	assert.Len(t, g.workItemQueue, 1)
+}

--- a/backend/executor_stream_test.go
+++ b/backend/executor_stream_test.go
@@ -309,3 +309,83 @@ func TestDispatchWorkflowWorkItem_OwnerBusyFallsBackAfterGrace(t *testing.T) {
 	require.NoError(t, g.dispatchWorkflowWorkItem(t.Context(), "stuck-owner", wi))
 	assert.Len(t, g.workItemQueue, 1)
 }
+
+// TestGetWorkItems_SendTimeoutCancelsPending exercises the
+// WithStreamSendTimeout path: a Send that never returns must fail the stream
+// with the timeout error, and the disconnect cleanup must cancel BOTH the
+// item stuck in the in-flight send and the items still buffered in the
+// outbox behind it.
+func TestGetWorkItems_SendTimeoutCancelsPending(t *testing.T) {
+	fb := newFakeExecBackend()
+	exec, _ := NewGrpcExecutor(fb, defaultLogger, WithStreamSendTimeout(3*time.Second))
+	g, ok := exec.(*grpcExecutor)
+	require.True(t, ok)
+
+	sendEntered := make(chan struct{})
+	unblockSend := make(chan struct{})
+	var sendOnce sync.Once
+	stream := &fakeWorkItemsStream{
+		ctx: t.Context(),
+		send: func(*protos.WorkItem) error {
+			sendOnce.Do(func() { close(sendEntered) })
+			<-unblockSend
+			return errors.New("stream torn down")
+		},
+	}
+	defer close(unblockSend)
+
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- g.GetWorkItems(statefulWorkItemsRequest(), stream)
+	}()
+
+	execDone := make(chan error, 3)
+	launch := func(iid string) {
+		go func() {
+			_, err := g.ExecuteWorkflow(t.Context(), api.InstanceID(iid), nil,
+				[]*protos.HistoryEvent{{EventId: 0}}, ExecuteOptions{})
+			execDone <- err
+		}()
+	}
+
+	// First item occupies the writer goroutine inside the blocked Send; the
+	// send timeout is now armed and counting.
+	launch("stuck-in-send")
+	select {
+	case <-sendEntered:
+	case <-time.After(30 * time.Second):
+		t.Fatal("first work item never reached Send")
+	}
+
+	// Two more items must be dispatched (stamped with this stream and queued
+	// in its outbox) before the armed timeout fires, so the cleanup below is
+	// provably covering buffered items and not just the in-flight one. An
+	// empty shared queue means the dispatch loop has picked both up; the
+	// bound is deliberately inside the 3s timeout so exceeding it fails here
+	// with a clear message instead of a confusing cancellation miss later.
+	launch("buffered-1")
+	launch("buffered-2")
+	require.Eventually(t, func() bool {
+		return len(g.workItemQueue) == 0
+	}, 2*time.Second, time.Millisecond, "buffered items were not dispatched before the send timeout")
+
+	select {
+	case err := <-streamDone:
+		require.ErrorContains(t, err, "timed out while sending work item")
+	case <-time.After(30 * time.Second):
+		t.Fatal("GetWorkItems did not return after the send timeout")
+	}
+
+	for range 3 {
+		select {
+		case err := <-execDone:
+			require.EqualError(t, err, "operation aborted")
+		case <-time.After(30 * time.Second):
+			t.Fatal("ExecuteWorkflow did not return after the send timeout")
+		}
+	}
+
+	assert.ElementsMatch(t,
+		[]api.InstanceID{"stuck-in-send", "buffered-1", "buffered-2"},
+		fb.canceledInstances())
+}


### PR DESCRIPTION
Every GetWorkItems stream ran strictly one-in-flight: the dispatch loop handed an item to the sender goroutine and then parked on an errCh rendezvous until stream.Send (delta rewrite, proto marshal, gRPC flow-control wait) drained. With 12 streams mesh-wide at ~4ms average send occupancy that is a hard ceiling of ~250 work items/s per stream, which at 7-9 work items per completion reproduces the measured ~348/s mesh plateau with CPU, DB, and network idle.

The serialization was also self-degrading through the affinity spill: a warm owner mid-send forced dispatchWorkflowWorkItem to spill the turn to the shared queue, a cold stream then sent the FULL history instead of a delta, sends got longer, the owner got busier, spills increased.

Decouple dispatch from send completion: each stream gets a bounded outbox and a single writer goroutine, so gRPC's one-Send-at-a-time rule per stream still holds but dispatch no longer waits per item. Per-instance ordering is unaffected: the orchestrator actor's turn lock holds from dispatch until the completion callback, so an instance never has two workflow work items in flight, and the single writer preserves FIFO within a stream regardless. A failed or timed-out send surfaces on sendFailed and tears the stream down, so the disconnect cleanup cancels every pending item stamped with the stream, exactly as before.

With sends pipelined the owner is only busy when its whole outbox is full, so give the warm owner a short grace before racing the shared queue, and drain affinity items ahead of the shared queue in the stream loop. The producer still never blocks solely on the owner.