### PR TITLE
fix: bring the async turn path to parity with ProcessWorkItem

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -222,7 +222,7 @@ func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.Instanc
 
 	req := &protos.WorkflowRequest{
 		InstanceId:        string(iid),
-		ExecutionId:       nil,
+		ExecutionId:       executionID(oldEvents, newEvents),
 		PastEvents:        oldEvents,
 		NewEvents:         newEvents,
 		PropagatedHistory: opts.PropagatedHistory,

--- a/backend/executor_async_executionid_test.go
+++ b/backend/executor_async_executionid_test.go
@@ -1,0 +1,66 @@
+package backend
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+type fakeCallbackBackend struct {
+	Backend
+}
+
+func (f *fakeCallbackBackend) OnActivityCompletion(*protos.ActivityRequest, func(*protos.ActivityResponse, error)) func() {
+	return func() {}
+}
+
+func (f *fakeCallbackBackend) OnWorkflowTaskCompletion(*protos.WorkflowRequest, func(*protos.WorkflowResponse, error)) func() {
+	return func() {}
+}
+
+// The async dispatch path must derive the WorkflowRequest's ExecutionId from
+// the history exactly like the synchronous ExecuteWorkflow does: SDKs seed
+// deterministic TaskExecutionId derivation with it, and a nil value makes a
+// recreated instance's activities collide with the prior run's.
+func Test_executeWorkflowAsync_carriesExecutionID(t *testing.T) {
+	g := &grpcExecutor{
+		workItemQueue:     make(chan *protos.WorkItem, 1),
+		pendingWorkflows:  &sync.Map{},
+		pendingActivities: &sync.Map{},
+		streams:           &sync.Map{},
+		backend:           &fakeCallbackBackend{},
+		logger:            DefaultLogger(),
+	}
+
+	execID := "9e2ab534-9f13-4d9a-a558-a68912ab2a68"
+	newEvents := []*protos.HistoryEvent{{
+		EventId:   -1,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name: "MyOrch",
+				WorkflowInstance: &protos.WorkflowInstance{
+					InstanceId:  "wf1",
+					ExecutionId: wrapperspb.String(execID),
+				},
+			},
+		},
+	}}
+
+	g.executeWorkflowAsync(context.Background(), api.InstanceID("wf1"), nil, newEvents, ExecuteOptions{}, func(*protos.WorkflowResponse, error) {})
+
+	select {
+	case wi := <-g.workItemQueue:
+		require.Equal(t, execID, wi.GetWorkflowRequest().GetExecutionId().GetValue())
+	default:
+		t.Fatal("the work item must have been queued")
+	}
+}

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -149,21 +149,10 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 				}
 			}
 
-			// A terminate in this batch must never be lost to ContinueAsNew.
-			// Strip any continue-as-new completion before applying actions:
-			// applying it would replace the state with a fresh generation,
-			// so the forced termination below would terminate that synthetic
-			// generation and the wipe would discard the child workflow
-			// history that cascade termination reads.
+			// A terminate in this batch must never be lost to
+			// ContinueAsNew; see stripContinueAsNewOnTerminate.
 			if terminateEvent != nil {
-				actions := results.Actions[:0]
-				for _, a := range results.Actions {
-					if co := a.GetCompleteWorkflow(); co != nil && co.WorkflowStatus == protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW {
-						continue
-					}
-					actions = append(actions, a)
-				}
-				results.Actions = actions
+				stripContinueAsNewOnTerminate(results)
 			}
 
 			// Apply the workflow outputs to the workflow state. The received
@@ -217,21 +206,8 @@ func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWor
 		// item and can never be re-delivered, so enforce it here: drop the
 		// doomed execution's pending work and complete as TERMINATED.
 		if terminateEvent != nil && !runtimestate.IsCompleted(wi.State) {
-			w.logger.Warnf("%v: workflow was terminated but the executor did not complete it; forcing termination", wi.InstanceID)
-			wi.State.PendingTasks = nil
-			wi.State.PendingTimers = nil
-			wi.State.PendingMessages = nil
-			forced := []*protos.WorkflowAction{{
-				Id: -1,
-				WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
-					CompleteWorkflow: &protos.CompleteWorkflowAction{
-						WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED,
-						Result:         terminateEvent.Input,
-					},
-				},
-			}}
-			if _, err := w.applier.Actions(wi.State, wi.State.CustomStatus, forced, helpers.TraceContextFromSpan(span), nil); err != nil {
-				return fmt.Errorf("failed to apply forced termination: %w", err)
+			if err := w.forceTermination(wi, terminateEvent, span); err != nil {
+				return err
 			}
 		}
 	}
@@ -360,6 +336,12 @@ func (t *workflowTurn) applyResponse(results *protos.WorkflowResponse, err error
 		}
 	}
 
+	// A terminate in this batch must never be lost to ContinueAsNew; see
+	// stripContinueAsNewOnTerminate.
+	if t.terminateEvent != nil {
+		stripContinueAsNewOnTerminate(results)
+	}
+
 	applyResult, err := w.applier.Actions(wi.State, results.CustomStatus, results.Actions, helpers.TraceContextFromSpan(t.span), execOpts.PropagatedHistory)
 	if err != nil {
 		t.finish(fmt.Errorf("failed to apply the execution result actions: %w", err))
@@ -385,11 +367,60 @@ func (t *workflowTurn) applyResponse(results *protos.WorkflowResponse, err error
 		return
 	}
 
+	// Mirror ProcessWorkItem: a consumed terminate the executor ignored is
+	// enforced here, since the event can never be re-delivered.
+	if t.terminateEvent != nil && !runtimestate.IsCompleted(wi.State) {
+		if ferr := w.forceTermination(wi, t.terminateEvent, t.span); ferr != nil {
+			t.finish(ferr)
+			return
+		}
+	}
+
 	if runtimestate.IsCompleted(wi.State) {
 		name, _ := runtimestate.Name(wi.State)
 		w.logger.Infof("%v: '%s' completed with a %s status.", wi.InstanceID, name, helpers.ToRuntimeStatusString(runtimestate.RuntimeStatus(wi.State)))
 	}
 	t.finish(nil)
+}
+
+// stripContinueAsNewOnTerminate removes any continue-as-new completion from
+// the executor's actions when the work item carried a terminate: applying it
+// would replace the state with a fresh generation, so the forced termination
+// would terminate that synthetic generation and the wipe would discard the
+// child workflow history that cascade termination reads.
+func stripContinueAsNewOnTerminate(results *protos.WorkflowResponse) {
+	actions := results.Actions[:0]
+	for _, a := range results.Actions {
+		if co := a.GetCompleteWorkflow(); co != nil && co.WorkflowStatus == protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW {
+			continue
+		}
+		actions = append(actions, a)
+	}
+	results.Actions = actions
+}
+
+// forceTermination drops the doomed execution's pending work and completes
+// the workflow as TERMINATED: used when a work item carried an
+// ExecutionTerminated event the executor did not honour, which is consumed
+// with the work item and can never be re-delivered.
+func (w *workflowProcessor) forceTermination(wi *WorkflowWorkItem, terminateEvent *protos.ExecutionTerminatedEvent, span trace.Span) error {
+	w.logger.Warnf("%v: workflow was terminated but the executor did not complete it; forcing termination", wi.InstanceID)
+	wi.State.PendingTasks = nil
+	wi.State.PendingTimers = nil
+	wi.State.PendingMessages = nil
+	forced := []*protos.WorkflowAction{{
+		Id: -1,
+		WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+			CompleteWorkflow: &protos.CompleteWorkflowAction{
+				WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED,
+				Result:         terminateEvent.Input,
+			},
+		},
+	}}
+	if _, err := w.applier.Actions(wi.State, wi.State.CustomStatus, forced, helpers.TraceContextFromSpan(span), nil); err != nil {
+		return fmt.Errorf("failed to apply forced termination: %w", err)
+	}
+	return nil
 }
 
 func (t *workflowTurn) finish(err error) {

--- a/backend/orchestration_terminate_test.go
+++ b/backend/orchestration_terminate_test.go
@@ -23,7 +23,7 @@ import (
 func newTerminatedTurn(t *testing.T, done func(error)) (*workflowTurn, *WorkflowWorkItem) {
 	t.Helper()
 
-	workflowID := "wf-terminate-async"
+	const workflowID = "wf-terminate-async"
 	state := runtimestate.NewWorkflowRuntimeState(workflowID, nil, nil)
 	terminate := &protos.ExecutionTerminatedEvent{Input: wrapperspb.String(`"reason"`)}
 	events := []*protos.HistoryEvent{
@@ -51,7 +51,7 @@ func newTerminatedTurn(t *testing.T, done func(error)) (*workflowTurn, *Workflow
 	}
 
 	wi := &WorkflowWorkItem{
-		InstanceID: "wf-terminate-async",
+		InstanceID: workflowID,
 		NewEvents:  events,
 		State:      state,
 	}
@@ -91,6 +91,7 @@ func Test_workflowTurn_applyResponse_forcesTerminateWhenExecutorIgnoresIt(t *tes
 	require.Equal(t, `"reason"`, output.GetValue())
 	require.Empty(t, wi.State.PendingTasks)
 	require.Empty(t, wi.State.PendingTimers)
+	require.Empty(t, wi.State.PendingMessages)
 }
 
 func Test_workflowTurn_applyResponse_terminateBeatsContinueAsNew(t *testing.T) {

--- a/backend/orchestration_terminate_test.go
+++ b/backend/orchestration_terminate_test.go
@@ -1,0 +1,119 @@
+package backend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/runtimestate"
+)
+
+// The async turn path (ProcessWorkItemAsync -> workflowTurn.applyResponse) is
+// what a callback-capable executor drives in production; these tests pin that
+// it enforces a mid-batch terminate exactly like the synchronous
+// ProcessWorkItem path.
+
+func newTerminatedTurn(t *testing.T, done func(error)) (*workflowTurn, *WorkflowWorkItem) {
+	t.Helper()
+
+	workflowID := "wf-terminate-async"
+	state := runtimestate.NewWorkflowRuntimeState(workflowID, nil, nil)
+	terminate := &protos.ExecutionTerminatedEvent{Input: wrapperspb.String(`"reason"`)}
+	events := []*protos.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(time.Now()),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "MyOrch",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId:  workflowID,
+						ExecutionId: wrapperspb.String(uuid.New().String()),
+					},
+				},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.New(time.Now()),
+			EventType: &protos.HistoryEvent_ExecutionTerminated{ExecutionTerminated: terminate},
+		},
+	}
+	for _, e := range events {
+		require.NoError(t, runtimestate.AddEvent(state, e))
+	}
+
+	wi := &WorkflowWorkItem{
+		InstanceID: "wf-terminate-async",
+		NewEvents:  events,
+		State:      state,
+	}
+	return &workflowTurn{
+		processor: &workflowProcessor{
+			logger:  DefaultLogger(),
+			applier: runtimestate.NewApplier("testapp", ""),
+		},
+		wi:             wi,
+		ctx:            context.Background(),
+		span:           trace.SpanFromContext(context.Background()),
+		terminateEvent: terminate,
+		done:           done,
+	}, wi
+}
+
+func Test_workflowTurn_applyResponse_forcesTerminateWhenExecutorIgnoresIt(t *testing.T) {
+	var doneErr error
+	turn, wi := newTerminatedTurn(t, func(err error) { doneErr = err })
+
+	turn.applyResponse(&protos.WorkflowResponse{
+		Actions: []*protos.WorkflowAction{{
+			Id: 0,
+			WorkflowActionType: &protos.WorkflowAction_CreateTimer{
+				CreateTimer: &protos.CreateTimerAction{
+					FireAt: timestamppb.New(time.Now().Add(time.Second)),
+				},
+			},
+		}},
+	}, nil, ExecuteOptions{})
+
+	require.NoError(t, doneErr)
+	require.True(t, runtimestate.IsCompleted(wi.State))
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, runtimestate.RuntimeStatus(wi.State))
+	output, err := runtimestate.Output(wi.State)
+	require.NoError(t, err)
+	require.Equal(t, `"reason"`, output.GetValue())
+	require.Empty(t, wi.State.PendingTasks)
+	require.Empty(t, wi.State.PendingTimers)
+}
+
+func Test_workflowTurn_applyResponse_terminateBeatsContinueAsNew(t *testing.T) {
+	var doneErr error
+	turn, wi := newTerminatedTurn(t, func(err error) { doneErr = err })
+
+	turn.applyResponse(&protos.WorkflowResponse{
+		Actions: []*protos.WorkflowAction{{
+			Id: 0,
+			WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+				CompleteWorkflow: &protos.CompleteWorkflowAction{
+					WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW,
+					Result:         wrapperspb.String(`"restart"`),
+				},
+			},
+		}},
+	}, nil, ExecuteOptions{})
+
+	require.NoError(t, doneErr)
+	require.True(t, runtimestate.IsCompleted(wi.State),
+		"the CAN must be stripped, not applied: no new generation may start")
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED, runtimestate.RuntimeStatus(wi.State))
+	output, err := runtimestate.Output(wi.State)
+	require.NoError(t, err)
+	require.Equal(t, `"reason"`, output.GetValue())
+}


### PR DESCRIPTION
The event-driven turn path a callback-capable executor drives in production (ProcessWorkItemAsync -> workflowTurn) diverged from the synchronous ProcessWorkItem path in two ways:

1. Mid-batch ExecutionTerminated enforcement (#123) was missing: a terminate the executor did not honour was consumed with its work item and lost, and the workflow kept running. The enforcement pieces (strip ContinueAsNew completions when a terminate is in the batch, force TERMINATED when the executor does not complete) are extracted into helpers shared by both paths.

2. executeWorkflowAsync hardcoded a nil WorkflowRequest.ExecutionId instead of deriving it from the history like ExecuteWorkflow does. SDKs seed their deterministic TaskExecutionId derivation with it, so a recreated instance's activities collided with the prior run's and were swallowed as retries of the completed execution.