### PR TITLE
make the event-driven path the only execution path

### DIFF
--- a/backend/activity.go
+++ b/backend/activity.go
@@ -64,74 +64,20 @@ func (ap *activityProcessor) NextWorkItem(ctx context.Context) (*ActivityWorkIte
 	return ap.be.NextActivityWorkItem(ctx)
 }
 
-// ProcessWorkItem implements TaskDispatcher
-func (p *activityProcessor) ProcessWorkItem(ctx context.Context, awi *ActivityWorkItem) error {
+// ProcessWorkItemAsync implements TaskProcessor: the post-execution work is
+// registered as a callback run by the goroutine that delivers the activity
+// result, so no goroutine waits out the app roundtrip. Executors that cannot
+// deliver by callback are invoked inline on the calling goroutine.
+func (p *activityProcessor) ProcessWorkItemAsync(ctx context.Context, awi *ActivityWorkItem, done func(error)) {
 	ts := awi.NewEvent.GetTaskScheduled()
-	if ts == nil {
-		return fmt.Errorf("%v: invalid TaskScheduled event", awi.InstanceID)
-	}
-	// Create span as child of spanContext found in TaskScheduledEvent
-	ctx, err := helpers.ContextFromTraceContext(ctx, ts.ParentTraceContext)
-	if err != nil {
-		return fmt.Errorf("%v: failed to parse activity trace context: %w", awi.InstanceID, err)
-	}
-	var span trace.Span
-	ctx, span = helpers.StartNewActivitySpan(ctx, ts.Name, ts.Version.GetValue(), string(awi.InstanceID), awi.NewEvent.EventId)
-	if span != nil {
-		defer func() {
-			if r := recover(); r != nil {
-				span.SetStatus(codes.Error, fmt.Sprintf("%v", r))
-			}
-			span.End()
-		}()
-	}
-
-	// set the parent trace context to be the newly created activity span
-	ts.ParentTraceContext = helpers.TraceContextFromSpan(span)
-
-	execOpts := ExecuteOptions{PropagatedHistory: awi.IncomingHistory}
-
-	// Execute the activity and get its result.
-	executor := p.executor
-	if p.inProcessExecutor != nil && p.inProcessNamePrefix != "" && strings.HasPrefix(ts.GetName(), p.inProcessNamePrefix) {
-		executor = p.inProcessExecutor
-	}
-	result, err := executor.ExecuteActivity(ctx, awi.InstanceID, awi.NewEvent, execOpts)
-	if err != nil {
-		if span != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-		}
-		return err
-	}
-	awi.Result = result
-	return nil
-}
-
-// ProcessWorkItemAsync implements AsyncTaskProcessor. It mirrors
-// ProcessWorkItem, with the post-execution work registered as a callback run
-// by the goroutine that delivers the activity result, so no goroutine waits
-// out the app roundtrip.
-func (p *activityProcessor) ProcessWorkItemAsync(ctx context.Context, awi *ActivityWorkItem, done func(error)) bool {
-	ts := awi.NewEvent.GetTaskScheduled()
-
-	executor := p.executor
-	if p.inProcessExecutor != nil && p.inProcessNamePrefix != "" && strings.HasPrefix(ts.GetName(), p.inProcessNamePrefix) {
-		executor = p.inProcessExecutor
-	}
-	asyncExecutor, ok := executor.(asyncActivityExecutor)
-	if !ok || !asyncExecutor.canExecuteAsync() {
-		return false
-	}
-
 	if ts == nil {
 		done(fmt.Errorf("%v: invalid TaskScheduled event", awi.InstanceID))
-		return true
+		return
 	}
 	ctx, err := helpers.ContextFromTraceContext(ctx, ts.ParentTraceContext)
 	if err != nil {
 		done(fmt.Errorf("%v: failed to parse activity trace context: %w", awi.InstanceID, err))
-		return true
+		return
 	}
 	var span trace.Span
 	ctx, span = helpers.StartNewActivitySpan(ctx, ts.Name, ts.Version.GetValue(), string(awi.InstanceID), awi.NewEvent.EventId)
@@ -141,7 +87,7 @@ func (p *activityProcessor) ProcessWorkItemAsync(ctx context.Context, awi *Activ
 
 	execOpts := ExecuteOptions{PropagatedHistory: awi.IncomingHistory}
 
-	asyncExecutor.executeActivityAsync(ctx, awi.InstanceID, awi.NewEvent, execOpts, func(result *protos.HistoryEvent, err error) {
+	settle := func(result *protos.HistoryEvent, err error) {
 		if span != nil {
 			if err != nil {
 				span.RecordError(err)
@@ -155,8 +101,25 @@ func (p *activityProcessor) ProcessWorkItemAsync(ctx context.Context, awi *Activ
 		}
 		awi.Result = result
 		done(nil)
-	})
-	return true
+	}
+
+	executor := p.executor
+	if p.inProcessExecutor != nil && p.inProcessNamePrefix != "" && strings.HasPrefix(ts.GetName(), p.inProcessNamePrefix) {
+		executor = p.inProcessExecutor
+	}
+	if asyncExecutor, ok := executor.(asyncActivityExecutor); ok && asyncExecutor.canExecuteAsync() {
+		asyncExecutor.executeActivityAsync(ctx, awi.InstanceID, awi.NewEvent, execOpts, settle)
+		return
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				settle(nil, fmt.Errorf("%v: activity executor panicked: %v", awi.InstanceID, r))
+			}
+		}()
+		settle(executor.ExecuteActivity(ctx, awi.InstanceID, awi.NewEvent, execOpts))
+	}()
 }
 
 // CompleteWorkItem implements TaskDispatcher

--- a/backend/activity_panic_test.go
+++ b/backend/activity_panic_test.go
@@ -1,0 +1,44 @@
+package backend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+type panickingActivityExecutor struct{}
+
+func (panickingActivityExecutor) ExecuteActivity(context.Context, api.InstanceID, *protos.HistoryEvent, ExecuteOptions) (*protos.HistoryEvent, error) {
+	panic("activity exploded")
+}
+
+// An executor panic in the inline branch must surface as an explicit error
+// through done, never crash the worker goroutine or complete the item.
+func Test_activityProcessor_inlineExecutorPanic(t *testing.T) {
+	p := &activityProcessor{executor: panickingActivityExecutor{}}
+
+	awi := &ActivityWorkItem{
+		InstanceID: "wf1",
+		NewEvent: &protos.HistoryEvent{
+			EventId:   0,
+			Timestamp: timestamppb.New(time.Now()),
+			EventType: &protos.HistoryEvent_TaskScheduled{
+				TaskScheduled: &protos.TaskScheduledEvent{Name: "Boom"},
+			},
+		},
+	}
+
+	var doneErr error
+	p.ProcessWorkItemAsync(context.Background(), awi, func(err error) { doneErr = err })
+
+	require.Error(t, doneErr)
+	assert.Contains(t, doneErr.Error(), "activity executor panicked")
+	assert.Nil(t, awi.Result, "a panicked execution must not produce a result")
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -140,24 +140,24 @@ type Backend interface {
 	// CompleteWorkflowTask completes the workflow task by saving the updated runtime state to durable storage.
 	CompleteWorkflowTask(context.Context, *protos.WorkflowResponse) error
 
-	// CancelWorkflowTask cancels the workflow task so instances of WaitForWorkflowTaskCompletion will return an error.
+	// CancelWorkflowTask cancels the workflow task, delivering
+	// [api.ErrTaskCancelled] to its completion registration.
 	CancelWorkflowTask(context.Context, api.InstanceID) error
 
-	// WaitForWorkflowTaskCompletion blocks until the workflow completes and returns the final response.
-	//
-	// [api.ErrTaskCancelled] is returned if the task was cancelled.
-	WaitForWorkflowTaskCompletion(*protos.WorkflowRequest) func(context.Context) (*protos.WorkflowResponse, error)
+	// OnWorkflowTaskCompletion registers a callback for the workflow task's
+	// completion; see the registration contract below.
+	OnWorkflowTaskCompletion(*protos.WorkflowRequest, func(*protos.WorkflowResponse, error)) func()
 
 	// CompleteActivityTask completes the activity task by saving the updated runtime state to durable storage.
 	CompleteActivityTask(context.Context, *protos.ActivityResponse) error
 
-	// CancelActivityTask cancels the activity task so instances of WaitForActivityCompletion will return an error.
+	// CancelActivityTask cancels the activity task, delivering
+	// [api.ErrTaskCancelled] to its completion registration.
 	CancelActivityTask(context.Context, api.InstanceID, int32) error
 
-	// WaitForActivityCompletion blocks until the activity completes and returns the final response.
-	//
-	// [api.ErrTaskCancelled] is returned if the task was cancelled.
-	WaitForActivityCompletion(*protos.ActivityRequest) func(context.Context) (*protos.ActivityResponse, error)
+	// OnActivityCompletion registers a callback for the activity task's
+	// completion; see the registration contract below.
+	OnActivityCompletion(*protos.ActivityRequest, func(*protos.ActivityResponse, error)) func()
 
 	// ListInstanceIDs lists workflow instance IDs based on the provided
 	// query parameters.
@@ -167,13 +167,11 @@ type Backend interface {
 	GetInstanceHistory(ctx context.Context, req *protos.GetInstanceHistoryRequest) (*protos.GetInstanceHistoryResponse, error)
 }
 
-// CompletionCallbackBackend is an optional interface a Backend can implement
-// to deliver task completions through a registered callback instead of waking
-// a goroutine blocked in WaitForWorkflowTaskCompletion or
-// WaitForActivityCompletion. The callback runs on the goroutine that delivers
-// the completion or cancellation, with the response, or with
+// Completion registration contract for OnWorkflowTaskCompletion and
+// OnActivityCompletion: the callback runs on the goroutine that delivers the
+// completion or cancellation, with the response, or with
 // [api.ErrTaskCancelled] if the task was cancelled. Registering replaces any
-// pending wait or callback for the same task.
+// pending callback for the same task.
 //
 // A registration is removed ONLY by the returned deregister closure, never by
 // delivering to the callback: the executor discards stale-token deliveries
@@ -183,11 +181,6 @@ type Backend interface {
 // callback may therefore be invoked more than once (stale deliveries
 // included); the executor's arbiter settles exactly one. Calling the
 // deregister closure after delivery, or more than once, is a no-op.
-type CompletionCallbackBackend interface {
-	OnWorkflowTaskCompletion(*protos.WorkflowRequest, func(*protos.WorkflowResponse, error)) func()
-
-	OnActivityCompletion(*protos.ActivityRequest, func(*protos.ActivityResponse, error)) func()
-}
 
 // MarshalHistoryEvent serializes the [HistoryEvent] into a protobuf byte array.
 func MarshalHistoryEvent(e *HistoryEvent) ([]byte, error) {

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -193,12 +193,11 @@ func (a *asyncWait) settle() bool {
 	return true
 }
 
-// canExecuteAsync reports whether the backend can deliver completions by
-// callback, which is what the executeWorkflowAsync and executeActivityAsync
-// paths need.
+// canExecuteAsync reports that completions are always deliverable by
+// callback: callback registration is part of the Backend contract, so the
+// event-driven path is the only execution path.
 func (g *grpcExecutor) canExecuteAsync() bool {
-	_, ok := g.backend.(CompletionCallbackBackend)
-	return ok
+	return true
 }
 
 // executeWorkflowAsync is the event-driven form of ExecuteWorkflow. Instead of
@@ -208,11 +207,6 @@ func (g *grpcExecutor) canExecuteAsync() bool {
 // the goroutine that delivers the completion, the cancellation, the context
 // error, or the dispatch failure.
 func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.InstanceID, oldEvents []*protos.HistoryEvent, newEvents []*protos.HistoryEvent, opts ExecuteOptions, done func(*protos.WorkflowResponse, error)) {
-	cbBackend, ok := g.backend.(CompletionCallbackBackend)
-	if !ok {
-		done(nil, errors.New("backend does not support completion callbacks"))
-		return
-	}
 
 	// Capture the tracked value: a superseded attempt settling late must not
 	// delete a newer attempt's entry (both share the instance key), or the
@@ -269,7 +263,7 @@ func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.Instanc
 		done(resp, nil)
 	}
 
-	wait.setDeregister(cbBackend.OnWorkflowTaskCompletion(req, deliver))
+	wait.setDeregister(g.backend.OnWorkflowTaskCompletion(req, deliver))
 	wait.setStop(context.AfterFunc(ctx, func() {
 		deliver(nil, ctx.Err())
 	}))
@@ -283,11 +277,6 @@ func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.Instanc
 // executeActivityAsync is the event-driven form of ExecuteActivity, with the
 // same contract as executeWorkflowAsync.
 func (g *grpcExecutor) executeActivityAsync(ctx context.Context, iid api.InstanceID, e *protos.HistoryEvent, opts ExecuteOptions, done func(*protos.HistoryEvent, error)) {
-	cbBackend, ok := g.backend.(CompletionCallbackBackend)
-	if !ok {
-		done(nil, errors.New("backend does not support completion callbacks"))
-		return
-	}
 
 	key := GetActivityExecutionKey(string(iid), e.EventId)
 	// See executeWorkflowAsync: CompareAndDelete-able so a late-settling
@@ -340,7 +329,7 @@ func (g *grpcExecutor) executeActivityAsync(ctx context.Context, iid api.Instanc
 		done(activityResponseEvent(e, task, resp), nil)
 	}
 
-	wait.setDeregister(cbBackend.OnActivityCompletion(req, deliver))
+	wait.setDeregister(g.backend.OnActivityCompletion(req, deliver))
 	wait.setStop(context.AfterFunc(ctx, func() {
 		deliver(nil, ctx.Err())
 	}))
@@ -373,107 +362,34 @@ func executionID(oldEvents, newEvents []*protos.HistoryEvent) *wrapperspb.String
 	return nil
 }
 
+// ExecuteWorkflow implements Executor as a blocking wrapper over
+// executeWorkflowAsync: the event-driven form is the single implementation
+// of workflow dispatch and completion delivery.
 func (executor *grpcExecutor) ExecuteWorkflow(ctx context.Context, iid api.InstanceID, oldEvents []*protos.HistoryEvent, newEvents []*protos.HistoryEvent, opts ExecuteOptions) (*protos.WorkflowResponse, error) {
-	trackedWorkflow := &pendingWorkflow{instanceID: iid}
-	executor.pendingWorkflows.Store(iid, trackedWorkflow)
-
-	req := &protos.WorkflowRequest{
-		InstanceId:        string(iid),
-		ExecutionId:       executionID(oldEvents, newEvents),
-		PastEvents:        oldEvents,
-		NewEvents:         newEvents,
-		PropagatedHistory: opts.PropagatedHistory,
+	type result struct {
+		resp *protos.WorkflowResponse
+		err  error
 	}
-
-	workItem := &protos.WorkItem{
-		Request: &protos.WorkItem_WorkflowRequest{
-			WorkflowRequest: req,
-		},
-	}
-
-	wait := executor.backend.WaitForWorkflowTaskCompletion(req)
-
-	// Send the workflow execution work-item to the connected worker.
-	// This will block if the worker isn't listening for work items.
-	// Worker-level routing (gRPC stream vs in-process internal executor)
-	// is handled upstream of this method by the TaskHubWorker reading WorkflowWorkItem.InProcess.
-	// In other words, this is always the external-stream path.
-	//
-	// The item prefers the stream that owns this instance under affinity (so the next
-	// turn can be a delta), falling back to any connected stream.
-	if err := executor.dispatchWorkflowWorkItem(ctx, iid, workItem); err != nil {
-		executor.logger.Warnf("%s: context canceled before dispatching workflow work item", iid)
-		return nil, fmt.Errorf("context canceled before dispatching workflow work item: %w", err)
-	}
-
-	resp, err := wait(ctx)
-
-	// This workflow is completed or cancelled and no longer pending. Remove
-	// only our own entry: a newer attempt may have re-stored the key.
-	executor.pendingWorkflows.CompareAndDelete(iid, trackedWorkflow)
-	if err != nil {
-		if errors.Is(err, api.ErrTaskCancelled) {
-			return nil, errors.New("operation aborted")
-		}
-		executor.logger.Warnf("%s: failed before receiving workflow result", iid)
-		return nil, err
-	}
-
-	return resp, nil
+	resultCh := make(chan result, 1)
+	executor.executeWorkflowAsync(ctx, iid, oldEvents, newEvents, opts, func(resp *protos.WorkflowResponse, err error) {
+		resultCh <- result{resp: resp, err: err}
+	})
+	r := <-resultCh
+	return r.resp, r.err
 }
 
 // ExecuteActivity implements Executor
 func (executor *grpcExecutor) ExecuteActivity(ctx context.Context, iid api.InstanceID, e *protos.HistoryEvent, opts ExecuteOptions) (*protos.HistoryEvent, error) {
-	key := GetActivityExecutionKey(string(iid), e.EventId)
-	trackedActivity := &pendingActivity{instanceID: iid, taskID: e.EventId}
-	executor.pendingActivities.Store(key, trackedActivity)
-
-	task := e.GetTaskScheduled()
-
-	req := &protos.ActivityRequest{
-		Name:               task.Name,
-		Version:            task.Version,
-		Input:              task.Input,
-		WorkflowInstance:   &protos.WorkflowInstance{InstanceId: string(iid)},
-		TaskId:             e.EventId,
-		TaskExecutionId:    task.TaskExecutionId,
-		ParentTraceContext: task.ParentTraceContext,
-		PropagatedHistory:  opts.PropagatedHistory,
+	type result struct {
+		event *protos.HistoryEvent
+		err   error
 	}
-	workItem := &protos.WorkItem{
-		Request: &protos.WorkItem_ActivityRequest{
-			ActivityRequest: req,
-		},
-	}
-
-	wait := executor.backend.WaitForActivityCompletion(req)
-
-	// Send the activity execution work-item to the connected worker.
-	// This will block if the worker isn't listening for work items.
-	// Worker-level routing (gRPC stream vs in-process internal executor)
-	// is handled upstream of this method by the TaskHubWorker reading WorkflowWorkItem.InProcess.
-	// In other words, this is always the external-stream path.
-	select {
-	case <-ctx.Done():
-		executor.logger.Warnf("%s/%s#%d: context canceled before dispatching activity work item", iid, task.Name, e.EventId)
-		return nil, fmt.Errorf("context canceled before dispatching activity work item: %w", ctx.Err())
-	case executor.workItemQueue <- workItem:
-	}
-
-	resp, err := wait(ctx)
-
-	// This activity is completed or cancelled and no longer pending. Remove
-	// only our own entry: a newer attempt may have re-stored the key.
-	executor.pendingActivities.CompareAndDelete(key, trackedActivity)
-	if err != nil {
-		if errors.Is(err, api.ErrTaskCancelled) {
-			return nil, errors.New("operation aborted")
-		}
-		executor.logger.Warnf("%s/%s#%d: failed before receiving activity result", iid, task.Name, e.EventId)
-		return nil, err
-	}
-
-	return activityResponseEvent(e, task, resp), nil
+	resultCh := make(chan result, 1)
+	executor.executeActivityAsync(ctx, iid, e, opts, func(event *protos.HistoryEvent, err error) {
+		resultCh <- result{event: event, err: err}
+	})
+	r := <-resultCh
+	return r.event, r.err
 }
 
 // activityResponseEvent maps an activity response onto the TaskFailed or

--- a/backend/executor_async_executionid_test.go
+++ b/backend/executor_async_executionid_test.go
@@ -31,12 +31,13 @@ func (f *fakeCallbackBackend) OnWorkflowTaskCompletion(*protos.WorkflowRequest, 
 // deterministic TaskExecutionId derivation with it, and a nil value makes a
 // recreated instance's activities collide with the prior run's.
 func Test_executeWorkflowAsync_carriesExecutionID(t *testing.T) {
+	fb := &fakeCallbackBackend{}
 	g := &grpcExecutor{
 		workItemQueue:     make(chan *protos.WorkItem, 1),
 		pendingWorkflows:  &sync.Map{},
 		pendingActivities: &sync.Map{},
 		streams:           &sync.Map{},
-		backend:           &fakeCallbackBackend{},
+		backend:           fb,
 		logger:            DefaultLogger(),
 	}
 

--- a/backend/executor_async_executionid_test.go
+++ b/backend/executor_async_executionid_test.go
@@ -26,10 +26,10 @@ func (f *fakeCallbackBackend) OnWorkflowTaskCompletion(*protos.WorkflowRequest, 
 	return func() {}
 }
 
-// The async dispatch path must derive the WorkflowRequest's ExecutionId from
-// the history exactly like the synchronous ExecuteWorkflow does: SDKs seed
-// deterministic TaskExecutionId derivation with it, and a nil value makes a
-// recreated instance's activities collide with the prior run's.
+// The dispatch must derive the WorkflowRequest's ExecutionId from the
+// history's ExecutionStarted event: SDKs seed deterministic TaskExecutionId
+// derivation with it, and a nil value makes a recreated instance's
+// activities collide with the prior run's.
 func Test_executeWorkflowAsync_carriesExecutionID(t *testing.T) {
 	fb := &fakeCallbackBackend{}
 	g := &grpcExecutor{

--- a/backend/executor_stream_test.go
+++ b/backend/executor_stream_test.go
@@ -43,22 +43,24 @@ func newFakeExecBackend() *fakeExecBackend {
 	return &fakeExecBackend{waiters: make(map[string]chan *protos.WorkflowResponse)}
 }
 
-func (f *fakeExecBackend) WaitForWorkflowTaskCompletion(req *protos.WorkflowRequest) func(context.Context) (*protos.WorkflowResponse, error) {
+func (f *fakeExecBackend) OnWorkflowTaskCompletion(req *protos.WorkflowRequest, cb func(*protos.WorkflowResponse, error)) func() {
 	ch := make(chan *protos.WorkflowResponse, 1)
 	f.mu.Lock()
 	f.waiters[req.GetInstanceId()] = ch
 	f.mu.Unlock()
-	return func(ctx context.Context) (*protos.WorkflowResponse, error) {
+	done := make(chan struct{})
+	go func() {
 		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		case <-done:
 		case resp := <-ch:
 			if resp == nil {
-				return nil, api.ErrTaskCancelled
+				cb(nil, api.ErrTaskCancelled)
+				return
 			}
-			return resp, nil
+			cb(resp, nil)
 		}
-	}
+	}()
+	return func() { close(done) }
 }
 
 func (f *fakeExecBackend) complete(iid string) {
@@ -105,7 +107,7 @@ type fakeWorkItemsStream struct {
 	send func(*protos.WorkItem) error
 }
 
-func (f *fakeWorkItemsStream) Context() context.Context      { return f.ctx }
+func (f *fakeWorkItemsStream) Context() context.Context       { return f.ctx }
 func (f *fakeWorkItemsStream) Send(wi *protos.WorkItem) error { return f.send(wi) }
 
 func statefulWorkItemsRequest() *protos.GetWorkItemsRequest {

--- a/backend/local/task.go
+++ b/backend/local/task.go
@@ -47,29 +47,6 @@ func (be *TasksBackend) CancelActivityTask(ctx context.Context, instanceID api.I
 	}
 	return api.NewUnknownTaskIDError(instanceID.String(), taskID)
 }
-
-func (be *TasksBackend) WaitForActivityCompletion(request *protos.ActivityRequest) func(context.Context) (*protos.ActivityResponse, error) {
-	key := backend.GetActivityExecutionKey(request.GetWorkflowInstance().GetInstanceId(), request.GetTaskId())
-	pending := &pendingActivity{
-		response: nil,
-		complete: make(chan struct{}, 1),
-	}
-	be.pendingActivities.Store(key, pending)
-
-	return func(ctx context.Context) (*protos.ActivityResponse, error) {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-pending.complete:
-			if pending.response == nil {
-				return nil, api.ErrTaskCancelled
-			}
-			return pending.response, nil
-		}
-	}
-}
-
-// OnActivityCompletion implements backend.CompletionCallbackBackend.
 func (be *TasksBackend) OnActivityCompletion(request *protos.ActivityRequest, cb func(*protos.ActivityResponse, error)) func() {
 	key := backend.GetActivityExecutionKey(request.GetWorkflowInstance().GetInstanceId(), request.GetTaskId())
 	pending := &pendingActivity{cb: cb}
@@ -93,28 +70,6 @@ func (be *TasksBackend) CancelWorkflowTask(ctx context.Context, instanceID api.I
 	}
 	return api.NewUnknownInstanceIDError(instanceID.String())
 }
-
-func (be *TasksBackend) WaitForWorkflowTaskCompletion(request *protos.WorkflowRequest) func(context.Context) (*protos.WorkflowResponse, error) {
-	pending := &pendingWorkflow{
-		response: nil,
-		complete: make(chan struct{}, 1),
-	}
-	be.pendingWorkflows.Store(request.GetInstanceId(), pending)
-
-	return func(ctx context.Context) (*protos.WorkflowResponse, error) {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-pending.complete:
-			if pending.response == nil {
-				return nil, api.ErrTaskCancelled
-			}
-			return pending.response, nil
-		}
-	}
-}
-
-// OnWorkflowTaskCompletion implements backend.CompletionCallbackBackend.
 func (be *TasksBackend) OnWorkflowTaskCompletion(request *protos.WorkflowRequest, cb func(*protos.WorkflowResponse, error)) func() {
 	key := request.GetInstanceId()
 	pending := &pendingWorkflow{cb: cb}

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -231,8 +231,9 @@ func (t *workflowTurn) applyResponse(results *protos.WorkflowResponse, err error
 		return
 	}
 
-	// Mirror ProcessWorkItem: a consumed terminate the executor ignored is
-	// enforced here, since the event can never be re-delivered.
+	// A terminate in this batch that the executor did not honour is
+	// enforced here: the event is consumed with this work item and can
+	// never be re-delivered.
 	if t.terminateEvent != nil && !runtimestate.IsCompleted(wi.State) {
 		if ferr := w.forceTermination(wi, t.terminateEvent, t.span); ferr != nil {
 			t.finish(ferr)

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -86,154 +86,19 @@ func (p *workflowProcessor) NextWorkItem(ctx context.Context) (*WorkflowWorkItem
 }
 
 // ProcessWorkItem implements TaskProcessor
-func (w *workflowProcessor) ProcessWorkItem(ctx context.Context, wi *WorkflowWorkItem) error {
-	w.logger.Debugf("%v: received work item with %d new event(s): %v", wi.InstanceID, len(wi.NewEvents), helpers.HistoryListSummary(wi.NewEvents))
-
-	// TODO: Caching
-	// In the fullness of time, we should consider caching executors and runtime state
-	// so that we can skip the loading of state and/or the creation of executors. A cached
-	// executor should allow us to 1) skip runtime state loading and 2) execute only new events.
-	if wi.State == nil {
-		if state, err := w.be.GetWorkflowRuntimeState(ctx, wi); err != nil {
-			return fmt.Errorf("failed to load workflow state: %w", err)
-		} else {
-			wi.State = state
-		}
-	}
-	w.logger.Debugf("%v: got workflow runtime state: %s", wi.InstanceID, getWorkflowStateDescription(wi))
-
-	var terminateEvent *protos.ExecutionTerminatedEvent = nil
-	for _, e := range wi.NewEvents {
-		if et := e.GetExecutionTerminated(); et != nil {
-			terminateEvent = et
-			break
-		}
-	}
-	if ctx, span, ok := w.applyWorkItem(ctx, wi); ok {
-		defer func() {
-			// Note that the span and ctx references may be updated inside the continue-as-new loop.
-			w.endWorkflowSpan(ctx, wi, span, false)
-		}()
-
-		for continueAsNewCount := 0; ; continueAsNewCount++ {
-			if continueAsNewCount > 0 {
-				w.logger.Debugf("%v: continuing-as-new with %d event(s): %s", wi.InstanceID, len(wi.State.NewEvents), helpers.HistoryListSummary(wi.State.NewEvents))
-			} else {
-				w.logger.Debugf("%v: invoking workflow", wi.InstanceID)
-			}
-
-			execOpts := ExecuteOptions{PropagatedHistory: wi.IncomingHistory}
-
-			// Run the user workflow code, providing the old history and new events together.
-			executor := w.executor
-			if w.inProcessExecutor != nil && w.inProcessNamePrefix != "" {
-				if name := wi.State.GetStartEvent().GetName(); strings.HasPrefix(name, w.inProcessNamePrefix) {
-					executor = w.inProcessExecutor
-				}
-			}
-			results, err := executor.ExecuteWorkflow(ctx, wi.InstanceID, wi.State.OldEvents, wi.State.NewEvents, execOpts)
-			if err != nil {
-				return fmt.Errorf("error executing workflow: %w", err)
-			}
-			w.logger.Debugf("%v: workflow returned %d action(s): %s", wi.InstanceID, len(results.Actions), helpers.ActionListSummary(results.Actions))
-
-			if version := results.GetVersion(); version != nil && (version.GetPatches() != nil || version.Name != nil) {
-				for _, e := range wi.State.NewEvents {
-					if os := e.GetWorkflowStarted(); os != nil {
-						os.Version = version
-						if len(version.GetPatches()) > 0 {
-							span.SetAttributes(attribute.StringSlice("applied_patches", version.GetPatches()))
-						}
-						break
-					}
-				}
-			}
-
-			// A terminate in this batch must never be lost to
-			// ContinueAsNew; see stripContinueAsNewOnTerminate.
-			if terminateEvent != nil {
-				stripContinueAsNewOnTerminate(results)
-			}
-
-			// Apply the workflow outputs to the workflow state. The received
-			// propagated history is passed through so the applier can assemble
-			// outgoing lineage propagation for children/activities.
-			applyResult, err := w.applier.Actions(wi.State, results.CustomStatus, results.Actions, helpers.TraceContextFromSpan(span), execOpts.PropagatedHistory)
-			if err != nil {
-				return fmt.Errorf("failed to apply the execution result actions: %w", err)
-			}
-
-			// Consumed by Dapr. dapr/dapr's actors backend implements the
-			// Backend interface; the workflow actor reads wi.OutgoingHistory
-			// and hands each PropagatedHistory to the activity actor, which
-			// stores it on reminder data and replays it when the activity
-			// runs. The in-process sqlite/postgres backends in this repo do
-			// not support propagation.
-			wi.OutgoingHistory = applyResult.OutgoingHistory
-
-			// When continuing-as-new, we re-execute the workflow from the beginning with a truncated state in a tight loop
-			// until the workflow performs some non-continue-as-new action.
-			if applyResult.ContinuedAsNew {
-				if continueAsNewCount >= maxContinueAsNewCount {
-					return fmt.Errorf("exceeded tight-loop continue-as-new limit of %d iterations", maxContinueAsNewCount)
-				}
-
-				// Carry the propagation chain forward across the CAN boundary so
-				// the next generation sees the prior generation's events as its
-				// IncomingHistory. Nil when the workflow did not participate in
-				// propagation.
-				if applyResult.NewIncomingHistory != nil {
-					wi.IncomingHistory = applyResult.NewIncomingHistory
-				}
-
-				// We create a new trace span for every continue-as-new
-				w.endWorkflowSpan(ctx, wi, span, true)
-				ctx, span = w.startOrResumeWorkflowSpan(ctx, wi)
-				continue
-			}
-
-			if runtimestate.IsCompleted(wi.State) {
-				name, _ := runtimestate.Name(wi.State)
-				w.logger.Infof("%v: '%s' completed with a %s status.", wi.InstanceID, name, helpers.ToRuntimeStatusString(runtimestate.RuntimeStatus(wi.State)))
-			}
-			break
-		}
-
-		// The work item carried an ExecutionTerminated event but the executor
-		// did not complete the workflow, e.g. because the terminate was not
-		// the last event in the batch or the workflow tried to
-		// continue-as-new. The terminate event is consumed with this work
-		// item and can never be re-delivered, so enforce it here: drop the
-		// doomed execution's pending work and complete as TERMINATED.
-		if terminateEvent != nil && !runtimestate.IsCompleted(wi.State) {
-			if err := w.forceTermination(wi, terminateEvent, span); err != nil {
-				return err
-			}
-		}
-	}
-	if terminateEvent != nil && runtimestate.IsCompleted(wi.State) {
-		appendCascadeTerminateMessages(wi.State, terminateEvent)
-	}
-	return nil
-}
-
-// ProcessWorkItemAsync implements AsyncTaskProcessor. It mirrors
-// ProcessWorkItem, with the work that follows each workflow execution
-// registered as a completion callback, so no goroutine waits out the app
-// roundtrip. A continue-as-new response starts its next execution from the
-// goroutine that delivered the previous one.
-func (w *workflowProcessor) ProcessWorkItemAsync(ctx context.Context, wi *WorkflowWorkItem, done func(error)) bool {
-	if asyncExecutor, ok := w.executor.(asyncWorkflowExecutor); !ok || !asyncExecutor.canExecuteAsync() {
-		return false
-	}
-
+// ProcessWorkItemAsync implements TaskProcessor: the work that follows each
+// workflow execution is registered as a completion callback, so no goroutine
+// waits out the app roundtrip. A continue-as-new response starts its next
+// execution from the goroutine that delivered the previous one. Executors
+// that cannot deliver by callback are invoked inline by the turn.
+func (w *workflowProcessor) ProcessWorkItemAsync(ctx context.Context, wi *WorkflowWorkItem, done func(error)) {
 	w.logger.Debugf("%v: received work item with %d new event(s): %v", wi.InstanceID, len(wi.NewEvents), helpers.HistoryListSummary(wi.NewEvents))
 
 	if wi.State == nil {
 		state, err := w.be.GetWorkflowRuntimeState(ctx, wi)
 		if err != nil {
 			done(fmt.Errorf("failed to load workflow state: %w", err))
-			return true
+			return
 		}
 		wi.State = state
 	}
@@ -253,7 +118,7 @@ func (w *workflowProcessor) ProcessWorkItemAsync(ctx context.Context, wi *Workfl
 			appendCascadeTerminateMessages(wi.State, terminateEvent)
 		}
 		done(nil)
-		return true
+		return
 	}
 
 	turn := &workflowTurn{
@@ -265,7 +130,6 @@ func (w *workflowProcessor) ProcessWorkItemAsync(ctx context.Context, wi *Workfl
 		done:           done,
 	}
 	turn.execute()
-	return true
 }
 
 // workflowTurn carries a workflow work item through its execute-apply loop in

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -85,7 +85,6 @@ func (p *workflowProcessor) NextWorkItem(ctx context.Context) (*WorkflowWorkItem
 	return p.be.NextWorkflowWorkItem(ctx)
 }
 
-// ProcessWorkItem implements TaskProcessor
 // ProcessWorkItemAsync implements TaskProcessor: the work that follows each
 // workflow execution is registered as a completion callback, so no goroutine
 // waits out the app roundtrip. A continue-as-new response starts its next
@@ -174,7 +173,16 @@ func (t *workflowTurn) execute() {
 		return
 	}
 
-	results, err := executor.ExecuteWorkflow(t.ctx, wi.InstanceID, wi.State.OldEvents, wi.State.NewEvents, execOpts)
+	var results *protos.WorkflowResponse
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				results, err = nil, fmt.Errorf("%v: workflow executor panicked: %v", wi.InstanceID, r)
+			}
+		}()
+		results, err = executor.ExecuteWorkflow(t.ctx, wi.InstanceID, wi.State.OldEvents, wi.State.NewEvents, execOpts)
+	}()
 	t.applyResponse(results, err, execOpts)
 }
 

--- a/backend/orchestration_panic_test.go
+++ b/backend/orchestration_panic_test.go
@@ -1,0 +1,45 @@
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/runtimestate"
+)
+
+type panickingWorkflowExecutor struct{}
+
+func (panickingWorkflowExecutor) ExecuteWorkflow(context.Context, api.InstanceID, []*protos.HistoryEvent, []*protos.HistoryEvent, ExecuteOptions) (*protos.WorkflowResponse, error) {
+	panic("workflow exploded")
+}
+
+// An inline executor panic must surface as an explicit error through the
+// turn's completion, never crash the delivering goroutine.
+func Test_workflowTurn_execute_inlineExecutorPanic(t *testing.T) {
+	var doneErr error
+	turn := &workflowTurn{
+		processor: &workflowProcessor{
+			logger:   DefaultLogger(),
+			executor: panickingWorkflowExecutor{},
+			applier:  runtimestate.NewApplier("testapp", ""),
+		},
+		wi: &WorkflowWorkItem{
+			InstanceID: "wf1",
+			State:      runtimestate.NewWorkflowRuntimeState("wf1", nil, nil),
+		},
+		ctx:  context.Background(),
+		span: trace.SpanFromContext(context.Background()),
+		done: func(err error) { doneErr = err },
+	}
+
+	turn.execute()
+
+	require.Error(t, doneErr)
+	assert.Contains(t, doneErr.Error(), "workflow executor panicked")
+}

--- a/backend/orchestration_terminate_test.go
+++ b/backend/orchestration_terminate_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/dapr/durabletask-go/backend/runtimestate"
 )
 
-// The async turn path (ProcessWorkItemAsync -> workflowTurn.applyResponse) is
-// what a callback-capable executor drives in production; these tests pin that
-// it enforces a mid-batch terminate exactly like the synchronous
-// ProcessWorkItem path.
+// The callback-driven turn (ProcessWorkItemAsync -> workflowTurn) is the
+// sole implementation of turn processing; these tests pin its mid-batch
+// terminate enforcement: a terminate the executor does not honour forces
+// TERMINATED and a ContinueAsNew cannot override it.
 
 func newTerminatedTurn(t *testing.T, done func(error)) (*workflowTurn, *WorkflowWorkItem) {
 	t.Helper()

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -15,23 +15,14 @@ type TaskWorker[T WorkItem] interface {
 
 type TaskProcessor[T WorkItem] interface {
 	Name() string
-	ProcessWorkItem(context.Context, T) error
+	// ProcessWorkItemAsync takes ownership of the work item and invokes done
+	// exactly once with the processing outcome, possibly before returning and
+	// possibly from the goroutine that delivers the work item's completion:
+	// no goroutine parks on the completion.
+	ProcessWorkItemAsync(ctx context.Context, wi T, done func(error))
 	NextWorkItem(context.Context) (T, error)
 	AbandonWorkItem(context.Context, T) error
 	CompleteWorkItem(context.Context, T) error
-}
-
-// AsyncTaskProcessor is an optional extension of TaskProcessor for processors
-// that can hand off a work item without a goroutine parked on the completion.
-//
-// When ProcessWorkItemAsync returns true it has taken ownership of the work
-// item and invokes done exactly once, with the same error ProcessWorkItem
-// would have returned, possibly before returning and possibly from the
-// goroutine that delivers the work item's completion. When it returns false it
-// has had no side effects and the caller must fall back to ProcessWorkItem.
-type AsyncTaskProcessor[T WorkItem] interface {
-	TaskProcessor[T]
-	ProcessWorkItemAsync(ctx context.Context, wi T, done func(error)) bool
 }
 
 type worker[T WorkItem] struct {
@@ -147,11 +138,7 @@ func (w *worker[T]) Start(ctx context.Context) {
 
 				w.logger.Debugf("%v: processing work item: %s", w.Name(), wi)
 
-				if ap, ok := w.processor.(AsyncTaskProcessor[T]); ok && ap.ProcessWorkItemAsync(ctx, wi, finish) {
-					return
-				}
-
-				finish(w.processor.ProcessWorkItem(ctx, wi))
+				w.processor.ProcessWorkItemAsync(ctx, wi, finish)
 			}()
 		}
 	}()

--- a/tests/mocks/Backend.go
+++ b/tests/mocks/Backend.go
@@ -1172,6 +1172,35 @@ func (_m *Backend) OnActivityCompletion(_a0 *protos.ActivityRequest, _a1 func(*p
 	return r0
 }
 
+// Backend_OnActivityCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OnActivityCompletion'
+type Backend_OnActivityCompletion_Call struct {
+	*mock.Call
+}
+
+// OnActivityCompletion is a helper method to define mock.On call
+//   - _a0 *protos.ActivityRequest
+//   - _a1 func(*protos.ActivityResponse, error)
+func (_e *Backend_Expecter) OnActivityCompletion(_a0 interface{}, _a1 interface{}) *Backend_OnActivityCompletion_Call {
+	return &Backend_OnActivityCompletion_Call{Call: _e.mock.On("OnActivityCompletion", _a0, _a1)}
+}
+
+func (_c *Backend_OnActivityCompletion_Call) Run(run func(_a0 *protos.ActivityRequest, _a1 func(*protos.ActivityResponse, error))) *Backend_OnActivityCompletion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*protos.ActivityRequest), args[1].(func(*protos.ActivityResponse, error)))
+	})
+	return _c
+}
+
+func (_c *Backend_OnActivityCompletion_Call) Return(_a0 func()) *Backend_OnActivityCompletion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Backend_OnActivityCompletion_Call) RunAndReturn(run func(*protos.ActivityRequest, func(*protos.ActivityResponse, error)) func()) *Backend_OnActivityCompletion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // OnWorkflowTaskCompletion provides a mock function with given fields: _a0, _a1
 func (_m *Backend) OnWorkflowTaskCompletion(_a0 *protos.WorkflowRequest, _a1 func(*protos.WorkflowResponse, error)) func() {
 	ret := _m.Called(_a0, _a1)
@@ -1190,6 +1219,35 @@ func (_m *Backend) OnWorkflowTaskCompletion(_a0 *protos.WorkflowRequest, _a1 fun
 	}
 
 	return r0
+}
+
+// Backend_OnWorkflowTaskCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OnWorkflowTaskCompletion'
+type Backend_OnWorkflowTaskCompletion_Call struct {
+	*mock.Call
+}
+
+// OnWorkflowTaskCompletion is a helper method to define mock.On call
+//   - _a0 *protos.WorkflowRequest
+//   - _a1 func(*protos.WorkflowResponse, error)
+func (_e *Backend_Expecter) OnWorkflowTaskCompletion(_a0 interface{}, _a1 interface{}) *Backend_OnWorkflowTaskCompletion_Call {
+	return &Backend_OnWorkflowTaskCompletion_Call{Call: _e.mock.On("OnWorkflowTaskCompletion", _a0, _a1)}
+}
+
+func (_c *Backend_OnWorkflowTaskCompletion_Call) Run(run func(_a0 *protos.WorkflowRequest, _a1 func(*protos.WorkflowResponse, error))) *Backend_OnWorkflowTaskCompletion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*protos.WorkflowRequest), args[1].(func(*protos.WorkflowResponse, error)))
+	})
+	return _c
+}
+
+func (_c *Backend_OnWorkflowTaskCompletion_Call) Return(_a0 func()) *Backend_OnWorkflowTaskCompletion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Backend_OnWorkflowTaskCompletion_Call) RunAndReturn(run func(*protos.WorkflowRequest, func(*protos.WorkflowResponse, error)) func()) *Backend_OnWorkflowTaskCompletion_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // WatchWorkflowRuntimeStatus provides a mock function with given fields: ctx, id, router, condition

--- a/tests/mocks/Backend.go
+++ b/tests/mocks/Backend.go
@@ -1152,100 +1152,44 @@ func (_c *Backend_Stop_Call) RunAndReturn(run func(context.Context) error) *Back
 	return _c
 }
 
-// WaitForActivityCompletion provides a mock function with given fields: _a0
-func (_m *Backend) WaitForActivityCompletion(_a0 *protos.ActivityRequest) func(context.Context) (*protos.ActivityResponse, error) {
-	ret := _m.Called(_a0)
+// OnActivityCompletion provides a mock function with given fields: _a0, _a1
+func (_m *Backend) OnActivityCompletion(_a0 *protos.ActivityRequest, _a1 func(*protos.ActivityResponse, error)) func() {
+	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
-		panic("no return value specified for WaitForActivityCompletion")
+		panic("no return value specified for OnActivityCompletion")
 	}
 
-	var r0 func(context.Context) (*protos.ActivityResponse, error)
-	if rf, ok := ret.Get(0).(func(*protos.ActivityRequest) func(context.Context) (*protos.ActivityResponse, error)); ok {
-		r0 = rf(_a0)
+	var r0 func()
+	if rf, ok := ret.Get(0).(func(*protos.ActivityRequest, func(*protos.ActivityResponse, error)) func()); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(func(context.Context) (*protos.ActivityResponse, error))
+			r0 = ret.Get(0).(func())
 		}
 	}
 
 	return r0
 }
 
-// Backend_WaitForActivityCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WaitForActivityCompletion'
-type Backend_WaitForActivityCompletion_Call struct {
-	*mock.Call
-}
-
-// WaitForActivityCompletion is a helper method to define mock.On call
-//   - _a0 *protos.ActivityRequest
-func (_e *Backend_Expecter) WaitForActivityCompletion(_a0 interface{}) *Backend_WaitForActivityCompletion_Call {
-	return &Backend_WaitForActivityCompletion_Call{Call: _e.mock.On("WaitForActivityCompletion", _a0)}
-}
-
-func (_c *Backend_WaitForActivityCompletion_Call) Run(run func(_a0 *protos.ActivityRequest)) *Backend_WaitForActivityCompletion_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*protos.ActivityRequest))
-	})
-	return _c
-}
-
-func (_c *Backend_WaitForActivityCompletion_Call) Return(_a0 func(context.Context) (*protos.ActivityResponse, error)) *Backend_WaitForActivityCompletion_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Backend_WaitForActivityCompletion_Call) RunAndReturn(run func(*protos.ActivityRequest) func(context.Context) (*protos.ActivityResponse, error)) *Backend_WaitForActivityCompletion_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// WaitForWorkflowTaskCompletion provides a mock function with given fields: _a0
-func (_m *Backend) WaitForWorkflowTaskCompletion(_a0 *protos.WorkflowRequest) func(context.Context) (*protos.WorkflowResponse, error) {
-	ret := _m.Called(_a0)
+// OnWorkflowTaskCompletion provides a mock function with given fields: _a0, _a1
+func (_m *Backend) OnWorkflowTaskCompletion(_a0 *protos.WorkflowRequest, _a1 func(*protos.WorkflowResponse, error)) func() {
+	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
-		panic("no return value specified for WaitForWorkflowTaskCompletion")
+		panic("no return value specified for OnWorkflowTaskCompletion")
 	}
 
-	var r0 func(context.Context) (*protos.WorkflowResponse, error)
-	if rf, ok := ret.Get(0).(func(*protos.WorkflowRequest) func(context.Context) (*protos.WorkflowResponse, error)); ok {
-		r0 = rf(_a0)
+	var r0 func()
+	if rf, ok := ret.Get(0).(func(*protos.WorkflowRequest, func(*protos.WorkflowResponse, error)) func()); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(func(context.Context) (*protos.WorkflowResponse, error))
+			r0 = ret.Get(0).(func())
 		}
 	}
 
 	return r0
-}
-
-// Backend_WaitForWorkflowTaskCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WaitForWorkflowTaskCompletion'
-type Backend_WaitForWorkflowTaskCompletion_Call struct {
-	*mock.Call
-}
-
-// WaitForWorkflowTaskCompletion is a helper method to define mock.On call
-//   - _a0 *protos.WorkflowRequest
-func (_e *Backend_Expecter) WaitForWorkflowTaskCompletion(_a0 interface{}) *Backend_WaitForWorkflowTaskCompletion_Call {
-	return &Backend_WaitForWorkflowTaskCompletion_Call{Call: _e.mock.On("WaitForWorkflowTaskCompletion", _a0)}
-}
-
-func (_c *Backend_WaitForWorkflowTaskCompletion_Call) Run(run func(_a0 *protos.WorkflowRequest)) *Backend_WaitForWorkflowTaskCompletion_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*protos.WorkflowRequest))
-	})
-	return _c
-}
-
-func (_c *Backend_WaitForWorkflowTaskCompletion_Call) Return(_a0 func(context.Context) (*protos.WorkflowResponse, error)) *Backend_WaitForWorkflowTaskCompletion_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Backend_WaitForWorkflowTaskCompletion_Call) RunAndReturn(run func(*protos.WorkflowRequest) func(context.Context) (*protos.WorkflowResponse, error)) *Backend_WaitForWorkflowTaskCompletion_Call {
-	_c.Call.Return(run)
-	return _c
 }
 
 // WatchWorkflowRuntimeStatus provides a mock function with given fields: ctx, id, router, condition

--- a/tests/mocks/task.go
+++ b/tests/mocks/task.go
@@ -90,18 +90,21 @@ func (t *TestTaskProcessor[T]) NextWorkItem(context.Context) (T, error) {
 	return wi, nil
 }
 
-func (t *TestTaskProcessor[T]) ProcessWorkItem(ctx context.Context, wi T) error {
+func (t *TestTaskProcessor[T]) ProcessWorkItemAsync(ctx context.Context, wi T, done func(error)) {
 	if !t.processingBlocked.Load() {
-		return nil
+		done(nil)
+		return
 	}
 	// wait for context cancellation or until processing is unblocked
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.New("dummy error processing work item")
+			done(errors.New("dummy error processing work item"))
+			return
 		default:
 			if !t.processingBlocked.Load() {
-				return nil
+				done(nil)
+				return
 			}
 			time.Sleep(time.Millisecond)
 		}

--- a/tests/worker_async_test.go
+++ b/tests/worker_async_test.go
@@ -34,7 +34,7 @@ func newAsyncTaskProcessor(cancelOnCtxDone bool) *asyncTaskProcessor {
 	}
 }
 
-func (p *asyncTaskProcessor) ProcessWorkItemAsync(ctx context.Context, wi *backend.ActivityWorkItem, done func(error)) bool {
+func (p *asyncTaskProcessor) ProcessWorkItemAsync(ctx context.Context, wi *backend.ActivityWorkItem, done func(error)) {
 	p.mu.Lock()
 	p.done = append(p.done, done)
 	p.mu.Unlock()
@@ -43,7 +43,6 @@ func (p *asyncTaskProcessor) ProcessWorkItemAsync(ctx context.Context, wi *backe
 			done(ctx.Err())
 		})
 	}
-	return true
 }
 
 func (p *asyncTaskProcessor) inFlight() int {


### PR DESCRIPTION
The workflow and activity processors carried two parallel
implementations of the same semantics: a synchronous path that parked a
goroutine per in-flight work item, and the event-driven callback path
that production runs. Every divergence between them became a production
bug (mid-batch terminate enforcement, the WorkflowRequest ExecutionId),
because unit tests exercised the sync path while only the async one
shipped. This removes the sync path entirely.

- Backend: OnWorkflowTaskCompletion and OnActivityCompletion are now
  required interface members and WaitForWorkflowTaskCompletion and
  WaitForActivityCompletion are removed, with the keep-armed
  registration contract documented on the interface. The local task
  hub keeps only its callback implementations; sqlite and postgres
  inherit them through the embedded TasksBackend. BREAKING: third
  party Backend implementations must implement the callback
  registrations and drop the waiter forms.
- TaskProcessor: ProcessWorkItemAsync replaces ProcessWorkItem and
  the optional AsyncTaskProcessor interface is merged away; the
  worker loop has no sync fallback. workflowTurn is the single
  implementation of turn semantics, including terminate enforcement
  and the continue-as-new loop. Executors that cannot deliver by
  callback (the in-process executor) are invoked inline by the turn.
- grpcExecutor keeps thin blocking ExecuteWorkflow/ExecuteActivity
  wrappers over the async forms to satisfy the Executor interface;
  an executor panic in the inline activity branch now surfaces as an
  explicit error instead of being swallowed into a nil-result
  failure.


Branched from #127 