### PR TITLE
backend: redeliver work items orphaned by a disconnecting stream

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -531,6 +531,11 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 		g.pendingWorkflows.Range(func(key, value any) bool {
 			if p, ok := value.(*pendingWorkflow); ok && p.streamID == streamID {
 				g.logger.Debugf("cleaning up pending workflow: %s", key)
+				// Cancellation is keyed by instance (the Backend interface
+				// carries no attempt identity); upstream per-instance
+				// serialization bounds the replacement race, and a spurious
+				// cancel of a fresh attempt aborts into its recoverable
+				// retry.
 				err := g.backend.CancelWorkflowTask(context.Background(), p.instanceID)
 				if err != nil {
 					g.logger.Warnf("failed to cancel workflow task: %v", err)

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -465,7 +465,7 @@ func (g *grpcExecutor) Shutdown(ctx context.Context) error {
 }
 
 // Hello implements protos.TaskHubSidecarServiceServer
-func (grpcExecutor) Hello(ctx context.Context, empty *emptypb.Empty) (*emptypb.Empty, error) {
+func (*grpcExecutor) Hello(ctx context.Context, empty *emptypb.Empty) (*emptypb.Empty, error) {
 	return empty, nil
 }
 
@@ -529,6 +529,10 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 				err := g.backend.CancelWorkflowTask(context.Background(), p.instanceID)
 				if err != nil {
 					g.logger.Warnf("failed to cancel workflow task: %v", err)
+					// Keep the entry: the backend completion waiter is still
+					// live, and a later cleanup (executor shutdown) must be
+					// able to retry the cancellation.
+					return true
 				}
 				// Only this stream's entry: a newer attempt from a fresh
 				// stream may have re-stored the key since the Range yielded.

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -471,6 +471,14 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 	// so the next turn for those instances falls back to a full history send.
 	ss := newStreamState(streamID, req)
 	g.streams.Store(streamID, ss)
+	// Registered before the registry delete so it runs after it (defers run
+	// LIFO): by drain time the stream is unroutable, so the buffer can only
+	// shrink. Without the drain, items routed into the affinity buffer but
+	// never pulled by the dispatch loop would die with the stream: they carry
+	// no streamID yet, so the pending cleanup below cannot cancel them, and
+	// the instance stalls with a registered completion waiter that nothing
+	// ever settles.
+	defer g.drainStreamBuffer(ss)
 	defer g.streams.Delete(streamID)
 
 	// There are some cases where the app may need to be notified when a client connects to fetch work items, like
@@ -487,6 +495,11 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 	}
 
 	defer func() {
+		// Stop producers routing new work into this stream's affinity buffer:
+		// affinityStreamOwner skips closed streams and in-flight producers
+		// re-check the flag after their grace window.
+		ss.closed.Store(true)
+
 		// If there's any pending activity left, remove them
 		g.pendingActivities.Range(func(key, value any) bool {
 			if p, ok := value.(*pendingActivity); ok && p.streamID == streamID {
@@ -508,6 +521,9 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 				if err != nil {
 					g.logger.Warnf("failed to cancel workflow task: %v", err)
 				}
+				// Only this stream's entry: a newer attempt from a fresh
+				// stream may have re-stored the key since the Range yielded.
+				g.pendingWorkflows.CompareAndDelete(key, value)
 			}
 			return true
 		})

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -57,7 +57,13 @@ type Executor interface {
 type grpcExecutor struct {
 	protos.UnimplementedTaskHubSidecarServiceServer
 
-	workItemQueue            chan *protos.WorkItem
+	workItemQueue chan *protos.WorkItem
+	// queueLock guards Shutdown's close of workItemQueue against the stream
+	// teardown drains that requeue buffered items onto it: a send racing the
+	// close would panic. Producers on the hot path do not take it; their
+	// lifecycle is ordered by the callers.
+	queueLock                sync.RWMutex
+	queueClosed              bool
 	pendingWorkflows         *sync.Map // map[api.InstanceID]*pendingWorkflow
 	pendingActivities        *sync.Map // map[string]*pendingActivity
 	streams                  *sync.Map // map[string]*streamState
@@ -425,8 +431,13 @@ func activityResponseEvent(e *protos.HistoryEvent, task *protos.TaskScheduledEve
 
 // Shutdown implements Executor
 func (g *grpcExecutor) Shutdown(ctx context.Context) error {
-	// closing the work item queue is a signal for shutdown
+	// closing the work item queue is a signal for shutdown; the lock fences
+	// stream-teardown drains, whose requeue onto a closed queue would panic
+	// (they fall back to cancelling the task once queueClosed is set).
+	g.queueLock.Lock()
+	g.queueClosed = true
 	close(g.workItemQueue)
+	g.queueLock.Unlock()
 
 	// Iterate through all pending items and close them to unblock the goroutines waiting on this
 	g.pendingActivities.Range(func(_, value any) bool {
@@ -472,12 +483,15 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 	ss := newStreamState(streamID, req)
 	g.streams.Store(streamID, ss)
 	// Registered before the registry delete so it runs after it (defers run
-	// LIFO): by drain time the stream is unroutable, so the buffer can only
-	// shrink. Without the drain, items routed into the affinity buffer but
-	// never pulled by the dispatch loop would die with the stream: they carry
-	// no streamID yet, so the pending cleanup below cannot cancel them, and
-	// the instance stalls with a registered completion waiter that nothing
-	// ever settles.
+	// LIFO): by drain time the stream is unroutable, and the drain's send
+	// lock waits out any producer that picked this owner before the removal,
+	// so a single drain empties the buffer for good. Registered before the
+	// connection callback below so a rejected connection also tears the
+	// published stream down through the same path. Without the drain, items
+	// routed into the affinity buffer but never pulled by the dispatch loop
+	// would die with the stream: they carry no streamID yet, so the pending
+	// cleanup below cannot cancel them, and the instance stalls with a
+	// registered completion waiter that nothing ever settles.
 	defer g.drainStreamBuffer(ss)
 	defer g.streams.Delete(streamID)
 
@@ -495,11 +509,6 @@ func (g *grpcExecutor) GetWorkItems(req *protos.GetWorkItemsRequest, stream prot
 	}
 
 	defer func() {
-		// Stop producers routing new work into this stream's affinity buffer:
-		// affinityStreamOwner skips closed streams and in-flight producers
-		// re-check the flag after their grace window.
-		ss.closed.Store(true)
-
 		// If there's any pending activity left, remove them
 		g.pendingActivities.Range(func(key, value any) bool {
 			if p, ok := value.(*pendingActivity); ok && p.streamID == streamID {

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -36,6 +36,10 @@ const streamOutboxSize = 64
 type pendingWorkflow struct {
 	instanceID api.InstanceID
 	streamID   string
+	// completionToken is the tracked dispatch's WorkItem.CompletionToken; a
+	// drained buffered item is only requeued or cancelled when its token
+	// still matches, so a stale attempt cannot disturb a newer registration.
+	completionToken string
 }
 
 type pendingActivity struct {
@@ -217,7 +221,8 @@ func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.Instanc
 	// Capture the tracked value: a superseded attempt settling late must not
 	// delete a newer attempt's entry (both share the instance key), or the
 	// newer dispatch loses stream-disconnect/shutdown cancellation.
-	trackedWorkflow := &pendingWorkflow{instanceID: iid}
+	dispatchToken := uuid.NewString()
+	trackedWorkflow := &pendingWorkflow{instanceID: iid, completionToken: dispatchToken}
 	g.pendingWorkflows.Store(iid, trackedWorkflow)
 
 	req := &protos.WorkflowRequest{
@@ -234,7 +239,7 @@ func (g *grpcExecutor) executeWorkflowAsync(ctx context.Context, iid api.Instanc
 	// history and strand the instance (the chaos-campaign janitor-livelock
 	// class). Workers that do not echo tokens send an empty one and keep
 	// today's behavior.
-	token := uuid.NewString()
+	token := dispatchToken
 	workItem := &protos.WorkItem{
 		Request: &protos.WorkItem_WorkflowRequest{
 			WorkflowRequest: req,

--- a/backend/executor_stateful.go
+++ b/backend/executor_stateful.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"hash/fnv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -49,10 +50,18 @@ type streamState struct {
 	// maxWarm is the soft cap on warm entries; defaults to maxWarmInstancesPerStream.
 	maxWarm int
 
-	// closed is set when the stream begins tearing down. Producers must not
-	// route new items into ch once set: the buffer is about to be drained and
-	// re-offered to the shared queue, and anything routed in afterwards would
-	// be orphaned with the dead stream.
+	// sendMu serializes producer sends into ch against teardown: producers
+	// hold it shared around the closed check and the send, teardown takes it
+	// exclusively to flip closed before draining. That guarantees no producer
+	// is between its closed check and its send when the buffer is drained, so
+	// nothing can land in the buffer afterwards.
+	sendMu sync.RWMutex
+
+	// closed is set (under sendMu) when the stream begins tearing down.
+	// Producers must not route new items into ch once set: the buffer is
+	// drained and re-offered to the shared queue, and anything routed in
+	// afterwards would be orphaned with the dead stream. Read lock-free by
+	// affinityStreamOwner as a cheap skim; trySend re-checks under sendMu.
 	closed atomic.Bool
 }
 
@@ -90,37 +99,23 @@ func (g *grpcExecutor) dispatchWorkflowWorkItem(ctx context.Context, iid api.Ins
 	owner := g.affinityStreamOwner(iid)
 	if owner != nil {
 		// Fast path: the owner is parked and ready, hand it over directly.
-		select {
-		case owner.ch <- wi:
+		if owner.trySend(wi) {
 			return nil
-		default:
 		}
-		// Owner busy: give it a short grace to drain before racing the shared
-		// queue, so a momentarily busy owner keeps the delta send. After the
-		// grace any free stream may take over, preserving the guarantee that
-		// the producer never blocks solely on the owner.
-		t := time.NewTimer(affinityOwnerGrace)
-		select {
-		case <-ctx.Done():
-			t.Stop()
-			return ctx.Err()
-		case owner.ch <- wi:
-			t.Stop()
+		// Owner busy: give it a short grace to drain before falling to the
+		// shared queue, so a momentarily busy owner keeps the delta send.
+		// After the grace any free stream may take over, preserving the
+		// guarantee that the producer never blocks solely on the owner. Both
+		// sends hold the stream's send lock shared, so they serialize with
+		// teardown: an item either lands before the teardown drain (and is
+		// re-offered to the shared queue) or the closed check diverts it
+		// here; it can never land in the buffer after the drain.
+		ok, err := owner.trySendGrace(ctx, wi, affinityOwnerGrace)
+		if err != nil {
+			return err
+		}
+		if ok {
 			return nil
-		case <-t.C:
-		}
-		// The owner may have begun tearing down during the grace; its buffer
-		// is about to be drained, so stop offering to it and take the shared
-		// queue only.
-		if !owner.closed.Load() {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case owner.ch <- wi:
-				return nil
-			case g.workItemQueue <- wi:
-				return nil
-			}
 		}
 	}
 
@@ -132,40 +127,48 @@ func (g *grpcExecutor) dispatchWorkflowWorkItem(ctx context.Context, iid api.Ins
 	}
 }
 
-// drainStreamBuffer re-offers work items still sitting in a closed stream's
-// affinity buffer to the shared queue so a surviving stream delivers them.
-// It runs after the stream is removed from the registry, but a producer that
-// chose this owner just before removal can still be inside its grace window,
-// so it drains a second time after a gap wider than the grace to catch
-// stragglers.
+// drainStreamBuffer marks the stream closed and re-offers work items still
+// sitting in its affinity buffer to the shared queue so a surviving stream
+// delivers them. Taking sendMu exclusively before flipping closed waits out
+// any producer already between its closed check and its send, so once the
+// drain starts nothing can land in the buffer: a single drain is complete.
 func (g *grpcExecutor) drainStreamBuffer(ss *streamState) {
-	for range 2 {
-		for {
-			select {
-			case wi := <-ss.ch:
-				g.requeueWorkItem(wi)
-			default:
-				goto wait
-			}
+	ss.sendMu.Lock()
+	ss.closed.Store(true)
+	ss.sendMu.Unlock()
+
+	for {
+		select {
+		case wi := <-ss.ch:
+			g.requeueWorkItem(wi)
+		default:
+			return
 		}
-	wait:
-		time.Sleep(affinityOwnerGrace * 2)
 	}
 }
 
-// requeueWorkItem puts an undelivered work item back on the shared queue.
-// The item was never sent to any worker, so redelivery is safe. If the queue
-// has no capacity, fall back to aborting the turn so the backend's retry
-// path re-derives it instead of it being lost.
+// requeueWorkItem puts an undelivered work item back on the shared queue. The
+// item was never sent to any worker, so redelivery is safe. When the executor
+// is shutting down (the shared queue is closed or closing) or the queue has no
+// capacity, fall back to aborting the turn so the backend's retry path
+// re-derives it instead of it being lost.
 func (g *grpcExecutor) requeueWorkItem(wi *protos.WorkItem) {
-	select {
-	case g.workItemQueue <- wi:
+	g.queueLock.RLock()
+	requeued := false
+	if !g.queueClosed {
+		select {
+		case g.workItemQueue <- wi:
+			requeued = true
+		default:
+		}
+	}
+	g.queueLock.RUnlock()
+	if requeued {
 		return
-	default:
 	}
 	if x, ok := wi.GetRequest().(*protos.WorkItem_WorkflowRequest); ok {
 		iid := api.InstanceID(x.WorkflowRequest.GetInstanceId())
-		g.logger.Warnf("shared queue full while draining a closed stream; cancelling workflow task for %s so it is redelivered", iid)
+		g.logger.Warnf("cannot requeue work item while draining a closed stream; cancelling workflow task for %s so it is redelivered", iid)
 		if err := g.backend.CancelWorkflowTask(context.Background(), iid); err != nil {
 			g.logger.Warnf("failed to cancel workflow task while draining closed stream: %v", err)
 		}
@@ -251,5 +254,42 @@ func (s *streamState) applyStatefulHistory(req *protos.WorkflowRequest) {
 				break
 			}
 		}
+	}
+}
+
+// trySend offers wi to this stream's affinity buffer without blocking.
+// Returns false when the buffer is full or the stream is tearing down.
+func (s *streamState) trySend(wi *protos.WorkItem) bool {
+	s.sendMu.RLock()
+	defer s.sendMu.RUnlock()
+	if s.closed.Load() {
+		return false
+	}
+	select {
+	case s.ch <- wi:
+		return true
+	default:
+		return false
+	}
+}
+
+// trySendGrace offers wi to this stream's affinity buffer, waiting up to
+// grace for buffer space. Returns false when the grace expires or the stream
+// is tearing down, and an error only when ctx is done.
+func (s *streamState) trySendGrace(ctx context.Context, wi *protos.WorkItem, grace time.Duration) (bool, error) {
+	s.sendMu.RLock()
+	defer s.sendMu.RUnlock()
+	if s.closed.Load() {
+		return false, nil
+	}
+	t := time.NewTimer(grace)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case s.ch <- wi:
+		return true, nil
+	case <-t.C:
+		return false, nil
 	}
 }

--- a/backend/executor_stateful.go
+++ b/backend/executor_stateful.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"hash/fnv"
+	"sync/atomic"
 	"time"
 
 	"github.com/dapr/durabletask-go/api"
@@ -47,6 +48,12 @@ type streamState struct {
 
 	// maxWarm is the soft cap on warm entries; defaults to maxWarmInstancesPerStream.
 	maxWarm int
+
+	// closed is set when the stream begins tearing down. Producers must not
+	// route new items into ch once set: the buffer is about to be drained and
+	// re-offered to the shared queue, and anything routed in afterwards would
+	// be orphaned with the dead stream.
+	closed atomic.Bool
 }
 
 func newStreamState(id string, req *protos.GetWorkItemsRequest) *streamState {
@@ -102,13 +109,18 @@ func (g *grpcExecutor) dispatchWorkflowWorkItem(ctx context.Context, iid api.Ins
 			return nil
 		case <-t.C:
 		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case owner.ch <- wi:
-			return nil
-		case g.workItemQueue <- wi:
-			return nil
+		// The owner may have begun tearing down during the grace; its buffer
+		// is about to be drained, so stop offering to it and take the shared
+		// queue only.
+		if !owner.closed.Load() {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case owner.ch <- wi:
+				return nil
+			case g.workItemQueue <- wi:
+				return nil
+			}
 		}
 	}
 
@@ -117,6 +129,46 @@ func (g *grpcExecutor) dispatchWorkflowWorkItem(ctx context.Context, iid api.Ins
 		return ctx.Err()
 	case g.workItemQueue <- wi:
 		return nil
+	}
+}
+
+// drainStreamBuffer re-offers work items still sitting in a closed stream's
+// affinity buffer to the shared queue so a surviving stream delivers them.
+// It runs after the stream is removed from the registry, but a producer that
+// chose this owner just before removal can still be inside its grace window,
+// so it drains a second time after a gap wider than the grace to catch
+// stragglers.
+func (g *grpcExecutor) drainStreamBuffer(ss *streamState) {
+	for range 2 {
+		for {
+			select {
+			case wi := <-ss.ch:
+				g.requeueWorkItem(wi)
+			default:
+				goto wait
+			}
+		}
+	wait:
+		time.Sleep(affinityOwnerGrace * 2)
+	}
+}
+
+// requeueWorkItem puts an undelivered work item back on the shared queue.
+// The item was never sent to any worker, so redelivery is safe. If the queue
+// has no capacity, fall back to aborting the turn so the backend's retry
+// path re-derives it instead of it being lost.
+func (g *grpcExecutor) requeueWorkItem(wi *protos.WorkItem) {
+	select {
+	case g.workItemQueue <- wi:
+		return
+	default:
+	}
+	if x, ok := wi.GetRequest().(*protos.WorkItem_WorkflowRequest); ok {
+		iid := api.InstanceID(x.WorkflowRequest.GetInstanceId())
+		g.logger.Warnf("shared queue full while draining a closed stream; cancelling workflow task for %s so it is redelivered", iid)
+		if err := g.backend.CancelWorkflowTask(context.Background(), iid); err != nil {
+			g.logger.Warnf("failed to cancel workflow task while draining closed stream: %v", err)
+		}
 	}
 }
 
@@ -130,7 +182,7 @@ func (g *grpcExecutor) affinityStreamOwner(iid api.InstanceID) *streamState {
 	var bestScore uint64
 	g.streams.Range(func(_, value any) bool {
 		ss, ok := value.(*streamState)
-		if !ok || !ss.statefulHistory {
+		if !ok || !ss.statefulHistory || ss.closed.Load() {
 			return true
 		}
 		score := rendezvousScore(iid, ss.id)

--- a/backend/executor_stateful.go
+++ b/backend/executor_stateful.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"hash/fnv"
 	"sync"
 	"sync/atomic"
@@ -150,15 +151,31 @@ func (g *grpcExecutor) drainStreamBuffer(ss *streamState) {
 // requeueWorkItem settles an undelivered work item pulled from a closed
 // stream's buffer: back onto the shared queue when it has capacity (the item
 // was never sent to any worker, so redelivery is safe), otherwise by
-// cancelling the task so the backend's retry path re-derives it. The item
-// carries a live completion waiter, so this must not give up: a transient
-// cancel error is retried with capped backoff, alternating with the requeue
-// attempt, until one of them succeeds. Blocking this teardown goroutine on a
-// persistently failing backend is deliberate and loudly logged; dropping the
-// item would strand the waiter until executor shutdown.
+// cancelling the task so the backend's retry path re-derives it. Both are
+// gated on the item still being the instance's tracked dispatch (completion
+// token match): a superseded or already-settled attempt is dropped so it
+// cannot disturb a newer registration. A live matching item must not be
+// given up on: a transient cancel error is retried with capped backoff,
+// alternating with the requeue attempt, until it is settled; an unknown
+// registration means it settled concurrently.
 func (g *grpcExecutor) requeueWorkItem(wi *protos.WorkItem) {
+	x, ok := wi.GetRequest().(*protos.WorkItem_WorkflowRequest)
+	if !ok {
+		// Only workflow items are affinity-routed, so only they can be
+		// drained here.
+		return
+	}
+	iid := api.InstanceID(x.WorkflowRequest.GetInstanceId())
+
 	backoff := 10 * time.Millisecond
 	for {
+		value, tracked := g.pendingWorkflows.Load(iid)
+		p, pok := value.(*pendingWorkflow)
+		if !tracked || !pok || p.completionToken != wi.GetCompletionToken() {
+			g.logger.Debugf("dropping drained work item for %s: its dispatch was superseded or already settled", iid)
+			return
+		}
+
 		g.queueLock.RLock()
 		requeued := false
 		if !g.queueClosed {
@@ -173,16 +190,13 @@ func (g *grpcExecutor) requeueWorkItem(wi *protos.WorkItem) {
 			return
 		}
 
-		x, ok := wi.GetRequest().(*protos.WorkItem_WorkflowRequest)
-		if !ok {
-			// Only workflow items are affinity-routed, so only they can be
-			// drained here.
-			return
-		}
-		iid := api.InstanceID(x.WorkflowRequest.GetInstanceId())
 		err := g.backend.CancelWorkflowTask(context.Background(), iid)
 		if err == nil {
 			g.logger.Warnf("cannot requeue work item while draining a closed stream; cancelled workflow task for %s so it is redelivered", iid)
+			return
+		}
+		if api.IsUnknownInstanceIDError(err) || errors.Is(err, api.ErrInstanceNotFound) {
+			// The registration is gone: the attempt settled concurrently.
 			return
 		}
 		g.logger.Warnf("failed to cancel workflow task for %s while draining a closed stream; retrying in %s: %v", iid, backoff, err)

--- a/backend/executor_stateful.go
+++ b/backend/executor_stateful.go
@@ -147,30 +147,48 @@ func (g *grpcExecutor) drainStreamBuffer(ss *streamState) {
 	}
 }
 
-// requeueWorkItem puts an undelivered work item back on the shared queue. The
-// item was never sent to any worker, so redelivery is safe. When the executor
-// is shutting down (the shared queue is closed or closing) or the queue has no
-// capacity, fall back to aborting the turn so the backend's retry path
-// re-derives it instead of it being lost.
+// requeueWorkItem settles an undelivered work item pulled from a closed
+// stream's buffer: back onto the shared queue when it has capacity (the item
+// was never sent to any worker, so redelivery is safe), otherwise by
+// cancelling the task so the backend's retry path re-derives it. The item
+// carries a live completion waiter, so this must not give up: a transient
+// cancel error is retried with capped backoff, alternating with the requeue
+// attempt, until one of them succeeds. Blocking this teardown goroutine on a
+// persistently failing backend is deliberate and loudly logged; dropping the
+// item would strand the waiter until executor shutdown.
 func (g *grpcExecutor) requeueWorkItem(wi *protos.WorkItem) {
-	g.queueLock.RLock()
-	requeued := false
-	if !g.queueClosed {
-		select {
-		case g.workItemQueue <- wi:
-			requeued = true
-		default:
+	backoff := 10 * time.Millisecond
+	for {
+		g.queueLock.RLock()
+		requeued := false
+		if !g.queueClosed {
+			select {
+			case g.workItemQueue <- wi:
+				requeued = true
+			default:
+			}
 		}
-	}
-	g.queueLock.RUnlock()
-	if requeued {
-		return
-	}
-	if x, ok := wi.GetRequest().(*protos.WorkItem_WorkflowRequest); ok {
+		g.queueLock.RUnlock()
+		if requeued {
+			return
+		}
+
+		x, ok := wi.GetRequest().(*protos.WorkItem_WorkflowRequest)
+		if !ok {
+			// Only workflow items are affinity-routed, so only they can be
+			// drained here.
+			return
+		}
 		iid := api.InstanceID(x.WorkflowRequest.GetInstanceId())
-		g.logger.Warnf("cannot requeue work item while draining a closed stream; cancelling workflow task for %s so it is redelivered", iid)
-		if err := g.backend.CancelWorkflowTask(context.Background(), iid); err != nil {
-			g.logger.Warnf("failed to cancel workflow task while draining closed stream: %v", err)
+		err := g.backend.CancelWorkflowTask(context.Background(), iid)
+		if err == nil {
+			g.logger.Warnf("cannot requeue work item while draining a closed stream; cancelled workflow task for %s so it is redelivered", iid)
+			return
+		}
+		g.logger.Warnf("failed to cancel workflow task for %s while draining a closed stream; retrying in %s: %v", iid, backoff, err)
+		time.Sleep(backoff)
+		if backoff < time.Second {
+			backoff *= 2
 		}
 	}
 }

--- a/backend/executor_stateful.go
+++ b/backend/executor_stateful.go
@@ -190,6 +190,11 @@ func (g *grpcExecutor) requeueWorkItem(wi *protos.WorkItem) {
 			return
 		}
 
+		if value, ok := g.pendingWorkflows.Load(iid); !ok || value != any(p) {
+			g.logger.Debugf("dropping drained work item for %s: its dispatch settled during the drain", iid)
+			return
+		}
+
 		err := g.backend.CancelWorkflowTask(context.Background(), iid)
 		if err == nil {
 			g.logger.Warnf("cannot requeue work item while draining a closed stream; cancelled workflow task for %s so it is redelivered", iid)

--- a/backend/executor_stateful_test.go
+++ b/backend/executor_stateful_test.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -339,4 +340,45 @@ func TestDispatchWorkflowWorkItem_ClosedOwnerFallsToSharedQueue(t *testing.T) {
 	require.NoError(t, g.dispatchWorkflowWorkItem(context.Background(), "wf-live", wi))
 	require.Len(t, g.workItemQueue, 1)
 	assert.Equal(t, "wf-live", (<-g.workItemQueue).GetWorkflowRequest().GetInstanceId())
+}
+
+// After Shutdown closed the shared queue, a stream teardown drain must not
+// panic on the send; it cancels the task so the backend's retry redelivers.
+func TestDrainStreamBuffer_ShutdownCancelsInsteadOfPanicking(t *testing.T) {
+	fb := &fakeCancelBackend{}
+	g := &grpcExecutor{
+		workItemQueue: make(chan *protos.WorkItem, 8),
+		streams:       &sync.Map{},
+		backend:       fb,
+		logger:        DefaultLogger(),
+	}
+	g.queueLock.Lock()
+	g.queueClosed = true
+	close(g.workItemQueue)
+	g.queueLock.Unlock()
+
+	ss := capableStream("dying")
+	ss.ch <- wfWorkItem("wf-shutdown")
+
+	require.NotPanics(t, func() { g.drainStreamBuffer(ss) })
+
+	fb.mu.Lock()
+	defer fb.mu.Unlock()
+	require.Len(t, fb.cancelled, 1)
+	assert.Equal(t, api.InstanceID("wf-shutdown"), fb.cancelled[0])
+}
+
+// A producer that selected an owner just before teardown must serialize with
+// the drain: its item either lands before the drain (re-offered) or diverts
+// to the shared queue, never into the dead buffer afterwards.
+func TestTrySend_ClosedStreamRefuses(t *testing.T) {
+	ss := capableStream("s")
+	require.True(t, ss.trySend(wfWorkItem("a")))
+	g := &grpcExecutor{workItemQueue: make(chan *protos.WorkItem, 8), streams: &sync.Map{}, logger: DefaultLogger()}
+	g.drainStreamBuffer(ss)
+	assert.False(t, ss.trySend(wfWorkItem("b")), "a drained stream must refuse new sends")
+	ok, err := ss.trySendGrace(context.Background(), wfWorkItem("c"), time.Millisecond)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, ss.ch, "nothing may land in the buffer after the drain")
 }

--- a/backend/executor_stateful_test.go
+++ b/backend/executor_stateful_test.go
@@ -15,6 +15,7 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"sync"
 	"testing"
@@ -381,4 +382,45 @@ func TestTrySend_ClosedStreamRefuses(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 	assert.Empty(t, ss.ch, "nothing may land in the buffer after the drain")
+}
+
+type flakyCancelBackend struct {
+	Backend
+	mu        sync.Mutex
+	failures  int
+	cancelled []api.InstanceID
+}
+
+func (f *flakyCancelBackend) CancelWorkflowTask(_ context.Context, iid api.InstanceID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("transient backend error")
+	}
+	f.cancelled = append(f.cancelled, iid)
+	return nil
+}
+
+// A transient cancel error during the drain fallback must not discard the
+// item: the completion waiter is live, so the drain retries until the item
+// is settled one way or the other.
+func TestRequeueWorkItem_RetriesTransientCancelFailure(t *testing.T) {
+	fb := &flakyCancelBackend{failures: 3}
+	g := &grpcExecutor{
+		workItemQueue: make(chan *protos.WorkItem),
+		streams:       &sync.Map{},
+		backend:       fb,
+		logger:        DefaultLogger(),
+	}
+	ss := capableStream("dying")
+	ss.ch <- wfWorkItem("wf-flaky")
+
+	g.drainStreamBuffer(ss)
+
+	fb.mu.Lock()
+	defer fb.mu.Unlock()
+	require.Len(t, fb.cancelled, 1, "the item must be settled once the transient error clears")
+	assert.Equal(t, api.InstanceID("wf-flaky"), fb.cancelled[0])
+	assert.Zero(t, fb.failures)
 }

--- a/backend/executor_stateful_test.go
+++ b/backend/executor_stateful_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package backend
 
 import (
+	"context"
 	"strconv"
 	"sync"
 	"testing"
@@ -233,4 +234,109 @@ func TestAffinityStreamOwner_MinimalRemapOnMembershipChange(t *testing.T) {
 			assert.Equal(t, prev, got, "instance %s must not remap when its owner stayed connected", iid)
 		}
 	}
+}
+
+func TestAffinityStreamOwner_SkipsClosedStreams(t *testing.T) {
+	closing := capableStream("closing")
+	survivor := capableStream("survivor")
+	g := streamsWith(closing, survivor)
+
+	closing.closed.Store(true)
+	for i := 0; i < 50; i++ {
+		owner := g.affinityStreamOwner(api.InstanceID("inst-" + strconv.Itoa(i)))
+		require.NotNil(t, owner)
+		assert.Equal(t, "survivor", owner.id,
+			"a stream that has begun tearing down must not be chosen as owner")
+	}
+}
+
+func wfWorkItem(iid string) *protos.WorkItem {
+	return &protos.WorkItem{Request: &protos.WorkItem_WorkflowRequest{
+		WorkflowRequest: workflowReq(iid, 0, 1),
+	}}
+}
+
+// A dying stream's affinity buffer must be re-offered to the shared queue so
+// a surviving worker delivers the items, instead of orphaning them with the
+// stream (which stalled the instance until an external recovery kicked in).
+func TestDrainStreamBuffer_RequeuesToSharedQueue(t *testing.T) {
+	g := &grpcExecutor{
+		workItemQueue: make(chan *protos.WorkItem, 8),
+		streams:       &sync.Map{},
+		logger:        DefaultLogger(),
+	}
+	ss := capableStream("dying")
+	ss.closed.Store(true)
+	ss.ch <- wfWorkItem("wf-a")
+	ss.ch <- wfWorkItem("wf-b")
+
+	g.drainStreamBuffer(ss)
+
+	require.Len(t, g.workItemQueue, 2)
+	got := map[string]struct{}{}
+	for i := 0; i < 2; i++ {
+		wi := <-g.workItemQueue
+		got[wi.GetWorkflowRequest().GetInstanceId()] = struct{}{}
+	}
+	assert.Contains(t, got, "wf-a")
+	assert.Contains(t, got, "wf-b")
+	assert.Empty(t, ss.ch, "the dying stream's buffer must be fully drained")
+}
+
+type fakeCancelBackend struct {
+	Backend
+	mu        sync.Mutex
+	cancelled []api.InstanceID
+}
+
+func (f *fakeCancelBackend) CancelWorkflowTask(_ context.Context, iid api.InstanceID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cancelled = append(f.cancelled, iid)
+	return nil
+}
+
+// When the shared queue has no capacity to absorb a drained item, the turn is
+// aborted so the backend's retry path re-derives it: degraded, but never lost.
+func TestDrainStreamBuffer_CancelsWhenQueueFull(t *testing.T) {
+	fb := &fakeCancelBackend{}
+	g := &grpcExecutor{
+		workItemQueue: make(chan *protos.WorkItem),
+		streams:       &sync.Map{},
+		backend:       fb,
+		logger:        DefaultLogger(),
+	}
+	ss := capableStream("dying")
+	ss.closed.Store(true)
+	ss.ch <- wfWorkItem("wf-orphan")
+
+	g.drainStreamBuffer(ss)
+
+	fb.mu.Lock()
+	defer fb.mu.Unlock()
+	require.Len(t, fb.cancelled, 1)
+	assert.Equal(t, api.InstanceID("wf-orphan"), fb.cancelled[0])
+}
+
+// A producer must not route into a closed owner's buffer: with the owner
+// closed the item takes the shared queue, where any surviving stream can
+// deliver it.
+func TestDispatchWorkflowWorkItem_ClosedOwnerFallsToSharedQueue(t *testing.T) {
+	owner := capableStream("owner")
+	g := streamsWith(owner)
+	g.workItemQueue = make(chan *protos.WorkItem, 1)
+	g.logger = DefaultLogger()
+
+	// Fill the owner's buffer so the fast path cannot accept, then close it:
+	// the post-grace re-check must divert to the shared queue rather than
+	// blocking on the dead owner.
+	for i := 0; i < cap(owner.ch); i++ {
+		owner.ch <- wfWorkItem("filler")
+	}
+	owner.closed.Store(true)
+
+	wi := wfWorkItem("wf-live")
+	require.NoError(t, g.dispatchWorkflowWorkItem(context.Background(), "wf-live", wi))
+	require.Len(t, g.workItemQueue, 1)
+	assert.Equal(t, "wf-live", (<-g.workItemQueue).GetWorkflowRequest().GetInstanceId())
 }

--- a/backend/executor_stateful_test.go
+++ b/backend/executor_stateful_test.go
@@ -258,15 +258,24 @@ func wfWorkItem(iid string) *protos.WorkItem {
 	}}
 }
 
+// trackWorkflow registers a pending entry matching wfWorkItem's (empty)
+// completion token, so the drain treats the item as the live dispatch.
+func trackWorkflow(g *grpcExecutor, iid string) {
+	g.pendingWorkflows.Store(api.InstanceID(iid), &pendingWorkflow{instanceID: api.InstanceID(iid)})
+}
+
 // A dying stream's affinity buffer must be re-offered to the shared queue so
 // a surviving worker delivers the items, instead of orphaning them with the
 // stream (which stalled the instance until an external recovery kicked in).
 func TestDrainStreamBuffer_RequeuesToSharedQueue(t *testing.T) {
 	g := &grpcExecutor{
-		workItemQueue: make(chan *protos.WorkItem, 8),
-		streams:       &sync.Map{},
-		logger:        DefaultLogger(),
+		workItemQueue:    make(chan *protos.WorkItem, 8),
+		pendingWorkflows: &sync.Map{},
+		streams:          &sync.Map{},
+		logger:           DefaultLogger(),
 	}
+	trackWorkflow(g, "wf-a")
+	trackWorkflow(g, "wf-b")
 	ss := capableStream("dying")
 	ss.closed.Store(true)
 	ss.ch <- wfWorkItem("wf-a")
@@ -303,11 +312,13 @@ func (f *fakeCancelBackend) CancelWorkflowTask(_ context.Context, iid api.Instan
 func TestDrainStreamBuffer_CancelsWhenQueueFull(t *testing.T) {
 	fb := &fakeCancelBackend{}
 	g := &grpcExecutor{
-		workItemQueue: make(chan *protos.WorkItem),
-		streams:       &sync.Map{},
-		backend:       fb,
-		logger:        DefaultLogger(),
+		workItemQueue:    make(chan *protos.WorkItem),
+		pendingWorkflows: &sync.Map{},
+		streams:          &sync.Map{},
+		backend:          fb,
+		logger:           DefaultLogger(),
 	}
+	trackWorkflow(g, "wf-orphan")
 	ss := capableStream("dying")
 	ss.closed.Store(true)
 	ss.ch <- wfWorkItem("wf-orphan")
@@ -348,16 +359,18 @@ func TestDispatchWorkflowWorkItem_ClosedOwnerFallsToSharedQueue(t *testing.T) {
 func TestDrainStreamBuffer_ShutdownCancelsInsteadOfPanicking(t *testing.T) {
 	fb := &fakeCancelBackend{}
 	g := &grpcExecutor{
-		workItemQueue: make(chan *protos.WorkItem, 8),
-		streams:       &sync.Map{},
-		backend:       fb,
-		logger:        DefaultLogger(),
+		workItemQueue:    make(chan *protos.WorkItem, 8),
+		pendingWorkflows: &sync.Map{},
+		streams:          &sync.Map{},
+		backend:          fb,
+		logger:           DefaultLogger(),
 	}
 	g.queueLock.Lock()
 	g.queueClosed = true
 	close(g.workItemQueue)
 	g.queueLock.Unlock()
 
+	trackWorkflow(g, "wf-shutdown")
 	ss := capableStream("dying")
 	ss.ch <- wfWorkItem("wf-shutdown")
 
@@ -375,7 +388,8 @@ func TestDrainStreamBuffer_ShutdownCancelsInsteadOfPanicking(t *testing.T) {
 func TestTrySend_ClosedStreamRefuses(t *testing.T) {
 	ss := capableStream("s")
 	require.True(t, ss.trySend(wfWorkItem("a")))
-	g := &grpcExecutor{workItemQueue: make(chan *protos.WorkItem, 8), streams: &sync.Map{}, logger: DefaultLogger()}
+	g := &grpcExecutor{workItemQueue: make(chan *protos.WorkItem, 8), pendingWorkflows: &sync.Map{}, streams: &sync.Map{}, logger: DefaultLogger()}
+	trackWorkflow(g, "a")
 	g.drainStreamBuffer(ss)
 	assert.False(t, ss.trySend(wfWorkItem("b")), "a drained stream must refuse new sends")
 	ok, err := ss.trySendGrace(context.Background(), wfWorkItem("c"), time.Millisecond)
@@ -408,11 +422,13 @@ func (f *flakyCancelBackend) CancelWorkflowTask(_ context.Context, iid api.Insta
 func TestRequeueWorkItem_RetriesTransientCancelFailure(t *testing.T) {
 	fb := &flakyCancelBackend{failures: 3}
 	g := &grpcExecutor{
-		workItemQueue: make(chan *protos.WorkItem),
-		streams:       &sync.Map{},
-		backend:       fb,
-		logger:        DefaultLogger(),
+		workItemQueue:    make(chan *protos.WorkItem),
+		pendingWorkflows: &sync.Map{},
+		streams:          &sync.Map{},
+		backend:          fb,
+		logger:           DefaultLogger(),
 	}
+	trackWorkflow(g, "wf-flaky")
 	ss := capableStream("dying")
 	ss.ch <- wfWorkItem("wf-flaky")
 
@@ -423,4 +439,75 @@ func TestRequeueWorkItem_RetriesTransientCancelFailure(t *testing.T) {
 	require.Len(t, fb.cancelled, 1, "the item must be settled once the transient error clears")
 	assert.Equal(t, api.InstanceID("wf-flaky"), fb.cancelled[0])
 	assert.Zero(t, fb.failures)
+}
+
+// A drained item whose dispatch was superseded (completion token no longer
+// matches the tracked entry) or already settled (no entry) must be dropped,
+// never requeued or cancelled against the live registration.
+func TestRequeueWorkItem_DropsSupersededOrSettled(t *testing.T) {
+	fb := &fakeCancelBackend{}
+	g := &grpcExecutor{
+		workItemQueue:    make(chan *protos.WorkItem, 8),
+		pendingWorkflows: &sync.Map{},
+		streams:          &sync.Map{},
+		backend:          fb,
+		logger:           DefaultLogger(),
+	}
+
+	// Superseded: a newer dispatch owns the entry with a different token.
+	g.pendingWorkflows.Store(api.InstanceID("wf-old"), &pendingWorkflow{
+		instanceID:      "wf-old",
+		completionToken: "newer-dispatch",
+	})
+	g.requeueWorkItem(wfWorkItem("wf-old"))
+
+	// Settled: no entry at all.
+	g.requeueWorkItem(wfWorkItem("wf-gone"))
+
+	assert.Empty(t, g.workItemQueue, "stale items must not be requeued")
+	fb.mu.Lock()
+	defer fb.mu.Unlock()
+	assert.Empty(t, fb.cancelled, "stale items must not cancel the live registration")
+}
+
+type unknownInstanceBackend struct {
+	Backend
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *unknownInstanceBackend) CancelWorkflowTask(_ context.Context, iid api.InstanceID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return &api.UnknownInstanceIDError{InstanceID: string(iid)}
+}
+
+// An unknown-registration error from the cancel fallback is permanent (the
+// attempt settled concurrently): the drain must treat it as settled, not
+// retry forever.
+func TestRequeueWorkItem_UnknownInstanceIsSettled(t *testing.T) {
+	fb := &unknownInstanceBackend{}
+	g := &grpcExecutor{
+		workItemQueue:    make(chan *protos.WorkItem),
+		pendingWorkflows: &sync.Map{},
+		streams:          &sync.Map{},
+		backend:          fb,
+		logger:           DefaultLogger(),
+	}
+	trackWorkflow(g, "wf-unknown")
+
+	done := make(chan struct{})
+	go func() {
+		g.requeueWorkItem(wfWorkItem("wf-unknown"))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("requeueWorkItem must return once the registration is unknown, not retry forever")
+	}
+	fb.mu.Lock()
+	defer fb.mu.Unlock()
+	assert.Equal(t, 1, fb.calls)
 }

--- a/backend/executor_stream_test.go
+++ b/backend/executor_stream_test.go
@@ -472,8 +472,10 @@ func TestGetWorkItems_DisconnectRedeliversBufferedItem(t *testing.T) {
 			return true
 		}
 		i++
+		iid := fmt.Sprintf("parked-%d", i)
+		g.pendingWorkflows.Store(api.InstanceID(iid), &pendingWorkflow{instanceID: api.InstanceID(iid)})
 		ok := ss.trySend(&protos.WorkItem{Request: &protos.WorkItem_WorkflowRequest{
-			WorkflowRequest: &protos.WorkflowRequest{InstanceId: fmt.Sprintf("parked-%d", i)},
+			WorkflowRequest: &protos.WorkflowRequest{InstanceId: iid},
 		}})
 		_ = ok
 		return false

--- a/backend/executor_stream_test.go
+++ b/backend/executor_stream_test.go
@@ -391,3 +391,105 @@ func TestGetWorkItems_SendTimeoutCancelsPending(t *testing.T) {
 		[]api.InstanceID{"stuck-in-send", "buffered-1", "buffered-2"},
 		fb.canceledInstances())
 }
+
+// TestGetWorkItems_DisconnectRedeliversBufferedItem exercises the teardown
+// path through a real GetWorkItems disconnect: items parked in the dying
+// stream's affinity buffer (never pulled by its dispatch loop) must be
+// re-offered to the shared queue and delivered by a surviving stream. This
+// covers the defer ordering (registry delete before drain, drain before the
+// stream returns) that the direct drainStreamBuffer tests cannot.
+func TestGetWorkItems_DisconnectRedeliversBufferedItem(t *testing.T) {
+	fb := newFakeExecBackend()
+	exec, _ := NewGrpcExecutor(fb, defaultLogger)
+	g, ok := exec.(*grpcExecutor)
+	require.True(t, ok)
+
+	// Survivor stream: plain (non-stateful) so it never becomes the affinity
+	// owner; it only consumes the shared queue.
+	var recMu sync.Mutex
+	survivorGot := map[string]bool{}
+	survivorCtx, survivorCancel := context.WithCancel(t.Context())
+	defer survivorCancel()
+	survivor := &fakeWorkItemsStream{
+		ctx: survivorCtx,
+		send: func(wi *protos.WorkItem) error {
+			recMu.Lock()
+			survivorGot[wi.GetWorkflowRequest().GetInstanceId()] = true
+			recMu.Unlock()
+			return nil
+		},
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, g.GetWorkItems(&protos.GetWorkItemsRequest{}, survivor))
+	}()
+
+	// Dying stream: stateful-history capable, its Send blocks forever so the
+	// dispatch loop backs up and items park in the affinity buffer.
+	dyingCtx, dyingCancel := context.WithCancel(t.Context())
+	defer dyingCancel()
+	blockSend := make(chan struct{})
+	defer close(blockSend)
+	dying := &fakeWorkItemsStream{
+		ctx: dyingCtx,
+		send: func(wi *protos.WorkItem) error {
+			select {
+			case <-blockSend:
+			case <-dyingCtx.Done():
+			}
+			return dyingCtx.Err()
+		},
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// The dying stream may return the failed send's error; teardown
+		// behavior is what this test asserts, not the return value.
+		_ = g.GetWorkItems(statefulWorkItemsRequest(), dying)
+	}()
+
+	// Wait for the dying stream to register, then locate its streamState.
+	var ss *streamState
+	require.Eventually(t, func() bool {
+		g.streams.Range(func(_, value any) bool {
+			if s, sok := value.(*streamState); sok && s.statefulHistory {
+				ss = s
+			}
+			return true
+		})
+		return ss != nil
+	}, time.Second*5, time.Millisecond)
+
+	// Route items into the affinity buffer until at least one is parked
+	// there (the dispatch loop drains into its outbox until the blocked
+	// writer backs it up; over-filling by the outbox size guarantees a
+	// residue in ss.ch).
+	i := 0
+	require.Eventually(t, func() bool {
+		if len(ss.ch) > 0 && i > streamOutboxSize {
+			return true
+		}
+		i++
+		ok := ss.trySend(&protos.WorkItem{Request: &protos.WorkItem_WorkflowRequest{
+			WorkflowRequest: &protos.WorkflowRequest{InstanceId: fmt.Sprintf("parked-%d", i)},
+		}})
+		_ = ok
+		return false
+	}, time.Second*5, time.Millisecond)
+
+	// Disconnect the dying stream: the parked residue must reach the
+	// survivor via the shared queue.
+	dyingCancel()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		recMu.Lock()
+		defer recMu.Unlock()
+		assert.NotEmpty(c, survivorGot, "a surviving stream must receive the items parked in the dead stream's buffer")
+	}, time.Second*10, time.Millisecond*5)
+
+	assert.Empty(t, ss.ch, "the dead stream's buffer must be fully drained")
+	survivorCancel()
+	wg.Wait()
+}

--- a/backend/historysigning/historysigning_test.go
+++ b/backend/historysigning/historysigning_test.go
@@ -87,7 +87,7 @@ func testEvents() []*protos.HistoryEvent {
 			Timestamp: timestamppb.New(time.Date(2026, 3, 18, 12, 0, 1, 0, time.UTC)),
 			EventType: &protos.HistoryEvent_ExecutionStarted{
 				ExecutionStarted: &protos.ExecutionStartedEvent{
-					Name: "TestWorkflow",
+					Name:  "TestWorkflow",
 					Input: wrapperspb.String(`{"key":"value"}`),
 					WorkflowInstance: &protos.WorkflowInstance{
 						InstanceId:  "test-instance-1",
@@ -914,9 +914,9 @@ func TestVerifyChainWithTrustAnchors(t *testing.T) {
 	// Verify with the correct CA as trust anchor — should pass.
 	_, err = VerifyChain(VerifyChainOptions{
 		RawSignatures: rawSigs,
-		Certs:        certs,
-		AllRawEvents: raw,
-		Signer:       tc,
+		Certs:         certs,
+		AllRawEvents:  raw,
+		Signer:        tc,
 	})
 	require.NoError(t, err)
 }
@@ -948,9 +948,9 @@ func TestVerifyChainWithWrongTrustAnchor(t *testing.T) {
 	tcVerify := newTestSigner(t, chainDER, leafPriv, wrongCA)
 	_, err = VerifyChain(VerifyChainOptions{
 		RawSignatures: rawSigs,
-		Certs:        certs,
-		AllRawEvents: raw,
-		Signer:       tcVerify,
+		Certs:         certs,
+		AllRawEvents:  raw,
+		Signer:        tcVerify,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "chain-of-trust verification failed for certificate index 0")
@@ -1026,9 +1026,9 @@ func TestVerifyChainWithIntermediateAndTrustAnchor(t *testing.T) {
 	// Verify with root as trust anchor — should pass via intermediate chain.
 	_, err = VerifyChain(VerifyChainOptions{
 		RawSignatures: rawSigs,
-		Certs:        certs,
-		AllRawEvents: raw,
-		Signer:       tc,
+		Certs:         certs,
+		AllRawEvents:  raw,
+		Signer:        tc,
 	})
 	require.NoError(t, err)
 }
@@ -1088,11 +1088,11 @@ func TestVerifyChainCertTrustCacheWindow(t *testing.T) {
 	tc := newTestSigner(t, certDER, priv, cert)
 
 	timestamps := []time.Time{
-		time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),  // T1: Jan
-		time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC),  // T2: Mar (extends max)
-		time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),  // T3: Feb (within [T1,T2], cached)
-		time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC),  // T4: Apr (beyond max, re-verify)
-		time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),   // T5: Mar (within [T1,T4], cached)
+		time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC), // T1: Jan
+		time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC), // T2: Mar (extends max)
+		time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), // T3: Feb (within [T1,T2], cached)
+		time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC), // T4: Apr (beyond max, re-verify)
+		time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),  // T5: Mar (within [T1,T4], cached)
 	}
 
 	// Create one event per signature, each with a different timestamp.
@@ -1132,9 +1132,9 @@ func TestVerifyChainCertTrustCacheWindow(t *testing.T) {
 	// Full chain verification should succeed.
 	_, err := VerifyChain(VerifyChainOptions{
 		RawSignatures: rawSigs,
-		Certs:        certs,
-		AllRawEvents: raw,
-		Signer:       tc,
+		Certs:         certs,
+		AllRawEvents:  raw,
+		Signer:        tc,
 	})
 	require.NoError(t, err)
 }
@@ -1190,9 +1190,9 @@ func TestVerifyChainCertTrustCacheWindowExpiredBefore(t *testing.T) {
 	// Should fail — the second event's timestamp is before the cert's NotBefore.
 	_, err = VerifyChain(VerifyChainOptions{
 		RawSignatures: rawSigs,
-		Certs:        certs,
-		AllRawEvents: raw,
-		Signer:       tc,
+		Certs:         certs,
+		AllRawEvents:  raw,
+		Signer:        tc,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "certificate not valid at event time")

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -716,7 +716,6 @@ func (be *sqliteBackend) GetWorkflowMetadata(ctx context.Context, iid api.Instan
 		return nil, err
 	}
 
-
 	startEvent, err := be.getStartEvent(ctx, iid)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Work items routed to a worker stream's affinity buffer but not yet pulled by its dispatch loop were lost when that stream disconnected: the disconnect cleanup cancels only pending items stamped with the stream's id, and the stamp is applied at send time, not at routing time. An item still sitting in the buffer carried no stamp, so it was neither cancelled nor redelivered, the registered completion waiter was never settled, and the instance stalled with its turn lock held (blocking the janitor as well). Reproduced by the dapr integration test daprd/workflow/statefulhistory/clientchurn, where all progress stops at the first worker disconnect.

Fixes:
- Streams are flagged closed at teardown start; affinityStreamOwner skips closed streams and dispatchWorkflowWorkItem re-checks the flag after its grace window, so producers stop routing into a dying buffer.
- After the stream is removed from the registry its affinity buffer is drained and every item is re-offered to the shared queue, where a surviving stream delivers it. The items were never sent to any worker, so redelivery is safe. The drain runs twice with a gap wider than the affinity grace to catch producers that chose the owner just before removal. If the shared queue has no capacity, the turn is cancelled so the backend's retry path re-derives it instead of losing it.
- The disconnect cleanup now deletes the pendingWorkflows entries it cancels (CompareAndDelete), matching the activity cleanup.